### PR TITLE
fix: devops artifacts were ignored during Additional Setup by VS Code Extension.

### DIFF
--- a/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
+++ b/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
@@ -62,9 +62,13 @@ function Get-ArtifactsFromEnvironment {
                     $artifactJson = '{"artifacts":[]}'
                 }
                 Write-Host "Artifacts: $artifactJson"
-                $artifacts = ($artifactJson | ConvertFrom-Json -ErrorAction SilentlyContinue).artifacts
+                $envArtifacts = ($artifactJson | ConvertFrom-Json -ErrorAction SilentlyContinue)
+                $artifacts = $envArtifacts.artifacts
                 if (! $artifacts) {
                     $artifacts = @()
+                }
+                if ($envArtifacts.devopsArtifacts) {
+                    $artifacts += $envArtifacts.devopsArtifacts
                 }
             }
         }


### PR DESCRIPTION
Related to: https://dev.azure.com/cc-ppi/General/_workitems/edit/641