### PR TITLE
Fix: "Start-NavAppDataUpgrade" was not executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 - DevOps artifacts were ignored
 - Support custom scripts
 - "Start-NavAppDataUpgrade" added to additional setup, when a data upgrade is needed during app install
+- Fix: "Start-NavAppDataUpgrade" was not executed, when previous app version was uninstalled during upgrade of another app (see [#1314](https://dev.azure.com/cc-ppi/General/_workitems/edit/1314))

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -94,7 +94,11 @@ function Import-AppArtifact {
                     Invoke-LogOperation -name "Uninstall old App" -started $started1 -properties $properties -success $success -telemetryClient $telemetryClient
                 }
             } else {
-                $runDataUpgrade = $false
+                if ($oldApp) {
+                    $runDataUpgrade = $true
+                } else {
+                    $runDataUpgrade = $false
+                } 
                 $success = $true
             }
     


### PR DESCRIPTION
- Fix: "Start-NavAppDataUpgrade" was not executed, when previous app version was uninstalled during upgrade of another app (see [#1314](https://dev.azure.com/cc-ppi/General/_workitems/edit/1314))
