### PR TITLE
Suppress configurable errors or warnings during logging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Support custom scripts
 - "Start-NavAppDataUpgrade" added to additional setup, when a data upgrade is needed during app install
 - Fix: "Start-NavAppDataUpgrade" was not executed, when previous app version was uninstalled during upgrade of another app (see [#1314](https://dev.azure.com/cc-ppi/General/_workitems/edit/1314))
+- Suppress configurable errors or warnings during logging. The suppressed message are then logged as information. (see [#1730](https://dev.azure.com/cc-ppi/General/_workitems/edit/1730))

--- a/artifacts/ArtifactHandling/Add-ArtifactsLog.ps1
+++ b/artifacts/ArtifactHandling/Add-ArtifactsLog.ps1
@@ -19,7 +19,7 @@ function Add-ArtifactsLog {
         [Parameter(Mandatory=$false)]
         [string]$artifactsLogFile = "C:/inetpub/wwwroot/http/artifacts.log.json",
         [switch]$lowerCase,
-        [string]$suppressedWarnings = $env:SUPPRESSED_WARINGS,
+        [string]$suppressedWarnings = $env:SUPPRESSED_WARNINGS,
         [string]$suppressedErrors = $env:SUPPRESSED_ERRORS
     )
     

--- a/artifacts/ArtifactHandling/Add-ArtifactsLog.ps1
+++ b/artifacts/ArtifactHandling/Add-ArtifactsLog.ps1
@@ -18,7 +18,9 @@ function Add-ArtifactsLog {
         [System.Object]$data = $null,
         [Parameter(Mandatory=$false)]
         [string]$artifactsLogFile = "C:/inetpub/wwwroot/http/artifacts.log.json",
-        [switch]$lowerCase
+        [switch]$lowerCase,
+        [string]$suppressedWarnings = $env:SUPPRESSED_WARINGS,
+        [string]$suppressedErrors = $env:SUPPRESSED_ERRORS
     )
     
     begin {
@@ -40,7 +42,22 @@ function Add-ArtifactsLog {
             "RIM" { $artifactsLog.Log += @($logEntry); }
             Default { $artifactsLog.Log += @($logEntry); }
         }
+        
+        switch ($severity) {
+            "Warn"  { 
+                if (($suppressedWarnings) -and ($message -match $suppressedWarnings)) {
+                    $severity = "Info"
+                }
+            }
+            "Error" { 
+                if (($suppressedErrors) -and ($message -match $suppressedErrors)) {
+                    $severity = "Info"
+                }
+            }
+        }
+
         $info   = "$("$kind".PadRight(4))$("[$severity]".ToUpper().PadLeft(6))"
+
         if (! $message) { Write-Host "$info "; return }
         switch ($severity) {
             "Info"  { foreach ($m in "$message".Trim().Split([System.Environment]::NewLine)) { if ($m) { Write-Host "$info $($m.trim())" } } }


### PR DESCRIPTION
Suppress configurable errors or warnings during logging. The suppressed message are then logged as information. (see [#1730](https://dev.azure.com/cc-ppi/General/_workitems/edit/1730))
#1730