### PR TITLE
Check for published app instead of installed

### DIFF
--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -72,8 +72,8 @@ function Import-AppArtifact {
                 $optionalParameters["Tenant"] = $Tenant
             }   
 
-            # Check if app is already installed with another version
-            $oldApp = (Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue) | Where-Object {$_.IsInstalled} | Select-Object -First 1
+            # Check if app is already published with another version
+            $oldApp = (Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue) | Select-Object -First 1
             
             # Uninstall old NAVApp, when present
             if($oldApp -and $oldApp.IsInstalled) {


### PR DESCRIPTION
Removed filter for installed apps because dependent apps of the app will be uninstalled when publishing the app and cant be found anymore leading to not be upgraded later. 

Additionally, check for installed is done below anyway.