### PR TITLE
check if psm exists

### DIFF
--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -53,7 +53,7 @@ if (Test-Path "$serviceTierFolder") {
     Write-Host "Import App Management Utils from $serviceTierFolder\Microsoft.Dynamics.Nav.Apps.Management.psd1"
     Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Apps.Management.psd1" -Force -ErrorAction SilentlyContinue -DisableNameChecking
 }
-if (Test-Path "$roleTailoredClientFolder") {
+if (Test-Path "$roleTailoredClientFolder\Microsoft.Dynamics.Nav.Ide.psm1") {
     Write-Host "Import Nav IDE from $roleTailoredClientFolder\Microsoft.Dynamics.Nav.Ide.psm1"
     Import-Module "$roleTailoredClientFolder\Microsoft.Dynamics.Nav.Ide.psm1" -Force -ErrorAction SilentlyContinue -DisableNameChecking
 }


### PR DESCRIPTION
Due to Microsoft removing the roletailored client the pipeline failed because it could not find the folder. Made the import conditional and only import powershell module if the psm file is found.