### PR TITLE
Mark errors during app install as error in log

### DIFF
--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -174,7 +174,7 @@ function Import-AppArtifact {
                     Install-NAVApp -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -Version $app.Version -Tenant $Tenant -Force -ErrorAction SilentlyContinue -ErrorVariable err -WarningVariable warn -InformationVariable info
                     $info | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Info  -data $app -lowerCase }
                     $warn | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Warn  -data $app -lowerCase }
-                    $err  | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Debug -data $app -lowerCase }
+                    $err  | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Error -data $app -lowerCase }
                     $success = ! $err
                     if ($success) { Add-ArtifactsLog -kind App -message "Install App ... successful" -data $app -success success }
                 } catch {        


### PR DESCRIPTION
Errors during install have been marked as debug and therefore have not been picked up by the pipeline. Change log output to error.