### PR TITLE
fix app exclude filter

### DIFF
--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -3,7 +3,7 @@ function Get-AppFilesSortedByDependencies {
     param(            
         [string] $Path,
         [string] $Filter  = "*.app",
-        [string[]] $Exclude = @("*Test_*","*Tests_*"),        
+        [string[]] $ExcludeExpr = ".*Test_.*|.*Tests_.*",        
         [bool] $Distinct = $true,
         [Parameter(Mandatory=$false)]
         $Depth
@@ -58,7 +58,7 @@ function Get-AppFilesSortedByDependencies {
         if ($Depth) {
             $optionalParameters["Depth"] = $Depth
         }
-        $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Exclude $Exclude -Recurse @optionalParameters
+        $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Recurse @optionalParameters | Where {$_.Name -NotMatch $ExcludeExpr}
 
         $AllApps = [System.Collections.ArrayList]@()
         foreach ($AppFile in $AllAppFiles) {


### PR DESCRIPTION
Due to a bug in windows powershell the Test-Apps are not excluded, as expected, during the container setup (Wait on Container start). (see explanation: https://stackoverflow.com/questions/38269209/using-get-childitem-exclude-or-include-returns-nothing)
Therefore, remove not working "-Exclude" switch of Get-ChildItem and replace it by a following (not matching) regular expression filter. 
