### PR TITLE
fix(module check): better check for PPI module

### DIFF
--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -67,7 +67,8 @@ if ("$($env:includeCSide)" -eq "y" -or (Test-Path "c:\navpfiles\")) {
 Write-Host ""
 Write-Host "=== Additional Setup ==="
 
-if ($env:IsBuildContainer) {
+$ppiau = Get-Module -Name PPIArtifactUtils
+if (-not $ppiau) {
     if (Test-Path "c:\run\PPIArtifactUtils.psd1") {
         Write-Host "Import PPI Setup Utils from c:\run\PPIArtifactUtils.psd1"
         Import-Module "c:\run\PPIArtifactUtils.psd1" -DisableNameChecking -Force


### PR DESCRIPTION
In some circumstances (old pipelines?) the old implementation might fail