### PR TITLE
feat(SaaS): Work with backups from BC Online with modified base app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - Add 4PS post startup handling to collect DLLs for base app modifications
 - Improve stability during upgrades for corner cases
 - Add ability to unpublish all apps as this is required for BC 20 -> 21 upgrades
+- Allow to work with BC Online backups from modified base app clusters

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -99,13 +99,16 @@ function Invoke-4PSArtifactHandling {
                                 Write-Host "    Skip import setup data from XML file as this seems to be a build container"
                             }                
                                 
-                            Write-Host "    Run manual data upgrade 4PS"
-                            Invoke-NavCodeunit `
-                                -ServerInstance BC `
-                                -CompanyName $companyName `
-                                -CodeunitId 50189 `
-                                -MethodName RunManualDataUpgrade `
-                                -Argument "$firstRun"
+                            if ($sysAppInfoFS.Version.Major -le 20) {
+                                # Only required on 20 and older
+                                Write-Host "    Run manual data upgrade 4PS"
+                                Invoke-NavCodeunit `
+                                    -ServerInstance BC `
+                                    -CompanyName $companyName `
+                                    -CodeunitId 50189 `
+                                    -MethodName RunManualDataUpgrade `
+                                    -Argument "$firstRun"
+                            }   
                                 
                             if ($env:IsBuildContainer -ne "true") {
                                 Write-Host "    Initialize FSA setup"

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -191,7 +191,7 @@ function Invoke-4PSArtifactHandling {
                 if ((Get-NAVServerUser -ServerInstance BC @tenantParam -ErrorAction Ignore | Where-Object { $_.UserName -eq $username })) {
                     # found existing user with given name
                     # in 4PS mode, we assume .bak with modified base app, so we push the password again as the standard user setup script would ignore this
-                    Set-NavServerUser -ServerInstance BC @tenantParam -Username $username -Password $securePassword -AuthenticationEMail $authenticationEMail
+                    Set-NavServerUser -ServerInstance BC @tenantParam -Username $username -Password $securePassword -AuthenticationEMail $username
                 }
 
                 Write-Host "  Add Control Add-Ins"

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -45,7 +45,9 @@ function Invoke-4PSArtifactHandling {
 
                 $sysAppInfoFS = Get-NAVAppInfo -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
                 $initializerVersion = ''
-                if ($sysAppInfoFS.Version.Major -ge 21) {
+                if ($sysAppInfoFS.Version.Major -eq 21) {
+                    $initializerVersion = "$($sysAppInfoFS.Version.Major).$($sysAppInfoFS.Version.Minor).1.0"
+                } elseif ($sysAppInfoFS.Version.Major -gt 21) {
                     $initializerVersion = "$($sysAppInfoFS.Version.Major).$($sysAppInfoFS.Version.Minor).0.0"
                 } elseif ($sysAppInfoFS.Version.Major -eq 20) {
                     $initializerVersion = '2.0.0.0'

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -191,7 +191,11 @@ function Invoke-4PSArtifactHandling {
                 if ((Get-NAVServerUser -ServerInstance BC @tenantParam -ErrorAction Ignore | Where-Object { $_.UserName -eq $username })) {
                     # found existing user with given name
                     # in 4PS mode, we assume .bak with modified base app, so we push the password again as the standard user setup script would ignore this
-                    Set-NavServerUser -ServerInstance BC @tenantParam -Username $username -Password $securePassword -AuthenticationEMail $username
+                    if ($env:Auth -eq "aad") {
+                        Set-NavServerUser -ServerInstance BC @tenantParam -Username $username -Password $securePassword -AuthenticationEMail $authenticationEMail
+                    } else {
+                        Set-NavServerUser -ServerInstance BC @tenantParam -Username $username -Password $securePassword 
+                    }
                 }
 
                 Write-Host "  Add Control Add-Ins"

--- a/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
+++ b/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
@@ -9,6 +9,8 @@
     The Nav/Bc Server Instance where apps must be unpublished, eg. 'ProdBc16'
     .PARAMETER Tenant
     The Tenant of the Server Instance where dataupgrade must be checked, eg. 'default'
+    .PARAMETER ExcludeSystemApp
+    If true, don't unpublish the system application
 #>
 
 function Unpublish-AllNavAppsInServerInstance {
@@ -16,7 +18,8 @@ function Unpublish-AllNavAppsInServerInstance {
     PARAM
     (
         [string]$ServerInstance,
-        [string]$Tenant
+        [string]$Tenant,
+        [switch]$ExcludeSystemApp = $false
     )
     PROCESS
     {
@@ -40,9 +43,13 @@ function Unpublish-AllNavAppsInServerInstance {
             $ExistingApps = Get-NAVAppInfo -ServerInstance $ServerInstance -TenantSpecificProperties -Tenant $Tenant 
         
             foreach ($ExistingApp in $ExistingApps) {  
-                unpublish-navapp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
-                if (!(get-navappinfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
-                    "App {0} with version {1} unpublished..." -f $ExistingApp.name, $ExistingApp.Version
+                if ("System Application" -eq $ExistingApp.name -and $ExcludeSystemApp) {
+                    Write-Host "Skipping the System Application"
+                } else {
+                    unpublish-navapp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
+                    if (!(get-navappinfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
+                        "App {0} with version {1} unpublished..." -f $ExistingApp.name, $ExistingApp.Version
+                    }
                 }
             }
         

--- a/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
+++ b/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
@@ -9,8 +9,6 @@
     The Nav/Bc Server Instance where apps must be unpublished, eg. 'ProdBc16'
     .PARAMETER Tenant
     The Tenant of the Server Instance where dataupgrade must be checked, eg. 'default'
-    .PARAMETER ExcludeSystemApp
-    If true, don't unpublish the system application
 #>
 
 function Unpublish-AllNavAppsInServerInstance {
@@ -18,8 +16,7 @@ function Unpublish-AllNavAppsInServerInstance {
     PARAM
     (
         [string]$ServerInstance,
-        [string]$Tenant,
-        [switch]$ExcludeSystemApp = $false
+        [string]$Tenant
     )
     PROCESS
     {
@@ -43,13 +40,9 @@ function Unpublish-AllNavAppsInServerInstance {
             $ExistingApps = Get-NAVAppInfo -ServerInstance $ServerInstance -TenantSpecificProperties -Tenant $Tenant 
         
             foreach ($ExistingApp in $ExistingApps) {  
-                if ("System Application" -eq $ExistingApp.name -and $ExcludeSystemApp) {
-                    Write-Host "Skipping the System Application"
-                } else {
-                    unpublish-navapp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
-                    if (!(get-navappinfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
-                        "App {0} with version {1} unpublished..." -f $ExistingApp.name, $ExistingApp.Version
-                    }
+                unpublish-navapp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
+                if (!(get-navappinfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
+                    "App {0} with version {1} unpublished..." -f $ExistingApp.name, $ExistingApp.Version
                 }
             }
         

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -347,7 +347,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host "Export NAVData"
         Export-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CRONUS" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
         Write-Host "Create new app database"
-        New-NAVApplicationDatabase -Collation $collation -DatabaseLocation $volPath -DatabaseName "CronusNew" -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance 
+        New-NAVApplicationDatabase -Collation $collation -DatabaseLocation $volPath -DatabaseName "CronusNew" -DatabaseServer $DatabaseServer
         Write-Host "Import NAVData"
         Import-NAVData -DatabaseServer $DatabaseServer -DatabaseName "CronusNew" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
         Write-Host "Stop server instance"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -132,7 +132,9 @@ if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     Write-Host "Identified SaaS Backup and 4PS mode, removing all apps to cleanly rebuild later"
     Unpublish-AllNavAppsInServerInstance
     Write-Host "Change collation"
-    Invoke-SqlCmd -Query "ALTER DATABASE CRONUS COLLATE Latin1_General_100_CI_AS ;"
+    Stop-NAVServerInstance -ServerInstance $ServerInstance
+    Invoke-SqlCmd -Query "ALTER DATABASE CRONUS SET SINGLE_USER WITH ROLLBACK IMMEDIATE; ALTER DATABASE CRONUS COLLATE Latin1_General_100_CI_AS ; ALTER DATABASE CRONUS SET MULTI_USER"
+    Start-NAVServerInstance -ServerInstance $ServerInstance
     $sysAppInfoFS = Get-NAVAppInfo -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -121,6 +121,7 @@ finally {
 
 # If SaaS backup for 4PS (modified base app), we need to remove the base app first
 if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
+    Write-Host "Identified SaaS Backup and 4PS mode, removing the base application"
     Uninstall-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
 }
 

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -345,7 +345,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host "Change collation to $collation"
         $navDataFilePath = (Join-Path $volPath "export.navdata")
         Write-Host "Export NAVData"
-        Export-NAVData -ServerInstance BC -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
+        Export-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CRONUS" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
         Write-Host "Create new app database"
         New-NAVApplicationDatabase -Collation $collation -DatabaseLocation $volPath -DatabaseName "CronusNew" -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance 
         Write-Host "Import NAVData"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -119,6 +119,11 @@ finally {
     Add-ArtifactsLog -message "Donwload Artifacts done."
 }
 
+# If SaaS backup for 4PS (modified base app), we need to remove the base app first
+if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
+    Uninstall-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
+}
+
 # Import Artifacts
 try {
     $SyncMode = $env:IMPORT_SYNC_MODE
@@ -223,7 +228,7 @@ if ($enablePerformanceCounter.ToLower() -eq "true") {
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile))
 {
     Write-Host "HANDLING SaaS BAKFILE"
-
+    
     $bak = $env:saasbakfile
     $tenantId = "saas"
     

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -14,11 +14,11 @@ function Move-Database {
         $smo.Databases | Where-Object { $_.Name -eq $databaseToMove } | ForEach-Object {
             # set recovery mode and shrink log
             $sqlcmd = "ALTER DATABASE [$($_.Name)] SET RECOVERY SIMPLE WITH NO_WAIT"
-            & sqlcmd -Q $sqlcmd
+            & sqlcmd -S 'localhost\SQLEXPRESS' -Q $sqlcmd
             $shrinkCmd = "USE [$($_.Name)]; "
             $_.LogFiles | ForEach-Object {
                 $shrinkCmd += "DBCC SHRINKFILE (N'$($_.Name)' , 10) WITH NO_INFOMSGS"
-                & sqlcmd -Q $shrinkCmd
+                & sqlcmd -S 'localhost\SQLEXPRESS' -Q $shrinkCmd
             }
 
             Write-Host " - - Moving $($_.Name)"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -337,7 +337,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     }
 
     # special handling for modified base app
-    if (!string.IsNullOrEmpty($env:cosmoBaseAppVersion)) {
+    if (![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)) {
         Write-Host "Set application version to $($app.Version) as this is a modified base app"
         Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
         Write-Host "Sync tenant"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -380,7 +380,6 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -EnvironmentType Sandbox `
         -OverwriteTenantIdInDatabase `
         -Force
-
         
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -340,14 +340,6 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     if (![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)) {
         Write-Host "Set application version to $($env:cosmoBaseAppVersion) as this is a modified base app"
         Set-NAVApplication -ApplicationVersion "$($env:cosmoBaseAppVersion)" -ServerInstance BC -Force -ErrorAction Stop
-        Write-Host "Start data upgrade"
-        Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force
-        Write-Host "Wait for data upgrade to finish"
-        Wait-DataUpgradeToFinish -ServerInstance BC 
-
-        Write-Host    "Check data upgrade is executed"
-        Set-NavServerInstance -ServerInstance BC -Restart
-        Check-DataUpgradeExecuted -ServerInstance BC -RequiredTenantDataVersion "$($env:cosmoBaseAppVersion)"
     }
 
     Write-Host " - Mounting SaaS tenant"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -122,7 +122,7 @@ finally {
 }
 
 # If SaaS backup, we will mount another tenant later anyway
-if (![string]::IsNullOrEmpty($env:saasbakfile) {
+if (![string]::IsNullOrEmpty($env:saasbakfile)) {
     Dismount-NAVTenant -ServerInstance $ServerInstance -Tenant "default" -Force
     Invoke-SqlCmd -Query "alter database [default] set single_user with rollback immediate; DROP DATABASE [default]"
 }

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -123,7 +123,7 @@ finally {
 if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     Write-Host "Identified SaaS Backup and 4PS mode, uninstalling and unpublishing the base application"
     Uninstall-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
-    Unpublish-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
+    Unpublish-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft"
 }
 
 # Import Artifacts

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -121,10 +121,12 @@ finally {
     Add-ArtifactsLog -message "Donwload Artifacts done."
 }
 
-# If SaaS backup, we will mount another tenant later anyway
+# If SaaS backup, we will mount another tenant later anyway, so we can remove the old one and don't have to sync
+$env:cosmoHasTenant = $true
 if (![string]::IsNullOrEmpty($env:saasbakfile)) {
     Dismount-NAVTenant -ServerInstance $ServerInstance -Tenant "default" -Force
     Invoke-SqlCmd -Query "alter database [default] set single_user with rollback immediate; DROP DATABASE [default]"
+    $env:cosmoHasTenant = $false
 }
 
 # If SaaS backup for 4PS (modified base app), we need to remove all apps and reinstall the System App first
@@ -138,10 +140,12 @@ if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     $sysAppInfoFS = Get-NAVAppInfo -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
-    Write-Host "  Sync the system application"
-    Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
-    Write-Host "  Install the system application"
-    Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+    if ($env:cosmoHasTenant) {
+        Write-Host "  Sync the system application"
+        Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+        Write-Host "  Install the system application"
+        Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+    }
 }
 
 # Import Artifacts
@@ -360,6 +364,8 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -EnvironmentType Sandbox `
         -OverwriteTenantIdInDatabase `
         -Force
+
+    $env:cosmoHasTenant = $true
         
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -338,8 +338,8 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
     # special handling for modified base app
     if (![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)) {
-        Write-Host "Set application version to $($app.Version) as this is a modified base app"
-        Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
+        Write-Host "Set application version to $($env:cosmoBaseAppVersion) as this is a modified base app"
+        Set-NAVApplication -ApplicationVersion "$($env:cosmoBaseAppVersion)" -ServerInstance BC -Force -ErrorAction Stop
         Write-Host "Sync tenant"
         Sync-NAVTenant -ServerInstance BC -Mode Sync -Force
         Write-Host "Start data upgrade"
@@ -349,7 +349,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
         Write-Host    "Check data upgrade is executed"
         Set-NavServerInstance -ServerInstance BC -Restart
-        Check-DataUpgradeExecuted -ServerInstance BC -RequiredTenantDataVersion "$($app.Version)"
+        Check-DataUpgradeExecuted -ServerInstance BC -RequiredTenantDataVersion "$($env:cosmoBaseAppVersion)"
     }
 
     Write-Host " - Mounting SaaS tenant"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -119,10 +119,10 @@ finally {
     Add-ArtifactsLog -message "Donwload Artifacts done."
 }
 
-# If SaaS backup for 4PS (modified base app), we need to remove the base app first
+# If SaaS backup for 4PS (modified base app), we need to remove all apps but the System App first
 if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     Write-Host "Identified SaaS Backup and 4PS mode, removing all apps to cleanly rebuild later"
-    Unpublish-AllNavAppsInServerInstance
+    Unpublish-AllNavAppsInServerInstance -ExcludeSystemApp
 }
 
 # Import Artifacts

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -349,7 +349,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host "Create new app database"
         New-NAVApplicationDatabase -Collation $collation -DatabaseLocation $volPath -DatabaseName "CronusNew" -DatabaseServer $DatabaseServer
         Write-Host "Import NAVData"
-        Import-NAVData -DatabaseServer $DatabaseServer -DatabaseName "CronusNew" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
+        Import-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CronusNew" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
         Write-Host "Stop server instance"
         Stop-NAVServerInstance BC
         Write-Host "Replace CRONUS database"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -121,8 +121,9 @@ finally {
 
 # If SaaS backup for 4PS (modified base app), we need to remove the base app first
 if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
-    Write-Host "Identified SaaS Backup and 4PS mode, removing the base application"
+    Write-Host "Identified SaaS Backup and 4PS mode, uninstalling and unpublishing the base application"
     Uninstall-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
+    Unpublish-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
 }
 
 # Import Artifacts

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -357,7 +357,6 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Export-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CRONUS" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
         Write-Host "Create new database with collation $collation"
         Invoke-SqlCmd -Query "CREATE DATABASE [CronusNew] COLLATE $collation"
-        Move-Database -databaseToMove "CronusNew"
         Write-Host "Import NAVData"
         Import-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CronusNew" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath -Force
         Write-Host "Stop server instance"
@@ -365,6 +364,8 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host "Replace CRONUS database"
         Invoke-SqlCmd -Query "alter database [CRONUS] set single_user with rollback immediate; DROP DATABASE [CRONUS]"
         Invoke-SqlCmd -Query "ALTER DATABASE CronusNew SET SINGLE_USER WITH ROLLBACK IMMEDIATE; ALTER DATABASE CronusNew MODIFY NAME = [CRONUS]; ALTER DATABASE [CRONUS] SET MULTI_USER"
+        Remove-Item (Join-Path $volPath "CRONUS") -recurse -force
+        Move-Database -databaseToMove "CRONUS"
         Write-Host "Start server instance"
         Start-NAVServerInstance BC
     }

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -121,9 +121,8 @@ finally {
 
 # If SaaS backup for 4PS (modified base app), we need to remove the base app first
 if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
-    Write-Host "Identified SaaS Backup and 4PS mode, uninstalling and unpublishing the base application"
-    Uninstall-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft" -Force
-    Unpublish-NAVApp -ServerInstance BC -Name "Base Application" -Publisher "Microsoft"
+    Write-Host "Identified SaaS Backup and 4PS mode, removing all apps to cleanly rebuild later"
+    Unpublish-AllNavAppsInServerInstance
 }
 
 # Import Artifacts

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -130,7 +130,7 @@ if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Sync the system application"
     Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
-    Write-Host "  Install the dsystem application"
+    Write-Host "  Install the system application"
     Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
 }
 
@@ -248,7 +248,7 @@ if ($enablePerformanceCounter.ToLower() -eq "true") {
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile))
 {
     Write-Host "HANDLING SaaS BAKFILE"
-    
+
     $bak = $env:saasbakfile
     $tenantId = "saas"
     

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -413,10 +413,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host " - Deactivate all users to ensure license compliance"
         Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | % {
             Write-Host " - Disable $($_.UserName)"
-            Set-NAVServerUser -UserName $_.UserName -State Disabled -ServerInstance $ServerInstance -Tenant $tenantId
+            Set-NAVServerUser -UserName $_.UserName -State Disabled -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction Continue
         }
-        New-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -Password $securePassword
-        New-NAVServerUserPermissionSet -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -PermissionSetId SUPER
+        New-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -Password $securePassword -ErrorAction Continue
+        New-NAVServerUserPermissionSet -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -PermissionSetId SUPER -ErrorAction Continue
     }
 
     Write-Host " - Importing License to new tenant"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -108,7 +108,7 @@ Invoke-LogEvent -name "AdditionalSetup - Started" -telemetryClient $telemetryCli
 try {
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and -not $_.name.StartsWith("sortorder"))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and !$_.name.StartsWith("sortorder"))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder")} | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
 
     $properties["artifats"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -108,7 +108,7 @@ Invoke-LogEvent -name "AdditionalSetup - Started" -telemetryClient $telemetryCli
 try {
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder"))))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder")} | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
 
     $properties["artifats"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -108,7 +108,7 @@ Invoke-LogEvent -name "AdditionalSetup - Started" -telemetryClient $telemetryCli
 try {
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and !$_.name.StartsWith("sortorder"))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder")} | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
 
     $properties["artifats"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -409,6 +409,11 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
     Write-Host " - Create user in new tenant (if not exists)"
     if(!(Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | Where-Object Username -eq $env:username)) {
+        Write-Host " - Deactivate all users to ensure license compliance"
+        Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | % {
+            Write-Host " - Disable $($_.UserName)"
+            Set-NAVServerUser -UserName $_.UserName -State Disabled -ServerInstance $ServerInstance -Tenant $tenantId
+        }
         New-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -Password $securePassword
         New-NAVServerUserPermissionSet -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -PermissionSetId SUPER
     }

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -122,11 +122,11 @@ finally {
 }
 
 # If SaaS backup, we will mount another tenant later anyway, so we can remove the old one and don't have to sync
-$env:cosmoHasTenant = $true
+$env:cosmoHasTenant = "true"
 if (![string]::IsNullOrEmpty($env:saasbakfile)) {
     Dismount-NAVTenant -ServerInstance $ServerInstance -Tenant "default" -Force
     Invoke-SqlCmd -Query "alter database [default] set single_user with rollback immediate; DROP DATABASE [default]"
-    $env:cosmoHasTenant = $false
+    $env:cosmoHasTenant = "false"
 }
 
 # If SaaS backup for 4PS (modified base app), we need to remove all apps and reinstall the System App first
@@ -140,7 +140,7 @@ if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     $sysAppInfoFS = Get-NAVAppInfo -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
-    if ($env:cosmoHasTenant) {
+    if ($env:cosmoHasTenant -eq "true") {
         Write-Host "  Sync the system application"
         Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
         Write-Host "  Install the system application"
@@ -365,7 +365,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -OverwriteTenantIdInDatabase `
         -Force
 
-    $env:cosmoHasTenant = $true
+    $env:cosmoHasTenant = "true"
         
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -108,8 +108,8 @@ Invoke-LogEvent -name "AdditionalSetup - Started" -telemetryClient $telemetryCli
 try {
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and -not $_.name.StartsWith("sortorder")  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.name.StartsWith("sortorder")} | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -ne $null -and -not $_.name.StartsWith("sortorder"))  } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder")} | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
 
     $properties["artifats"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -340,8 +340,6 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     if (![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)) {
         Write-Host "Set application version to $($env:cosmoBaseAppVersion) as this is a modified base app"
         Set-NAVApplication -ApplicationVersion "$($env:cosmoBaseAppVersion)" -ServerInstance BC -Force -ErrorAction Stop
-        Write-Host "Sync tenant"
-        Sync-NAVTenant -ServerInstance BC -Mode Sync -Force
         Write-Host "Start data upgrade"
         Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force
         Write-Host "Wait for data upgrade to finish"

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -128,8 +128,6 @@ if (![string]::IsNullOrEmpty($env:saasbakfile) -and $env:mode -eq "4ps") {
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Sync the system application"
     Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
-    Write-Host "  Start data upgrade for the system application"
-    Start-NAVAppDataUpgrade -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
     Write-Host "  Install the dsystem application"
     Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
 }

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -346,7 +346,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         $navDataFilePath = (Join-Path $volPath "export.navdata")
         Write-Host "Export NAVData"
         Export-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CRONUS" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath
-        Write-Host "Create new app database"
+        Write-Host "Create new app database with collation $collation at $volPath with server $DatabaseServer"
         New-NAVApplicationDatabase -Collation $collation -DatabaseLocation $volPath -DatabaseName "CronusNew" -DatabaseServer $DatabaseServer
         Write-Host "Import NAVData"
         Import-NAVData -ApplicationDatabaseServer $DatabaseServer -ApplicationDatabaseName "CronusNew" -IncludeApplication -IncludeApplicationData -FilePath $navDataFilePath

--- a/artifacts/AdditionalSetup.ps1
+++ b/artifacts/AdditionalSetup.ps1
@@ -415,7 +415,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     }
 
     Write-Host " - Create user in new tenant (if not exists)"
-    if(!(Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | Where-Object { $_.UserName.ToLower() -ne $env:username.ToLower() })) {
+    if(!(Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | Where-Object { $_.UserName.ToLower() -eq $env:username.ToLower() })) {
         New-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -Password $securePassword -AuthenticationEMail $env:username -ErrorAction Continue
         New-NAVServerUserPermissionSet -ServerInstance $ServerInstance -Tenant $tenantId -UserName $env:username -PermissionSetId SUPER -ErrorAction Continue
     }

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -190,9 +190,12 @@ function Import-AppArtifact {
             if ($IsModifiedBaseApp) {
                 Write-Host "Set application version to $($app.Version) as this is a modified base app"
                 Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
-                Sync-NAVTenant -ServerInstance BC -Mode Sync -Force -ErrorAction Stop
-                Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Stop 
-                Wait-DataUpgradeToFinish -ServerInstance BC -ErrorAction Stop 
+                Write-Host "Sync tenant"
+                Sync-NAVTenant -ServerInstance BC -Mode Sync -Force
+                Write-Host "Start data upgrade"
+                Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force
+                Write-Host "Wait for data upgrade to finish"
+                Wait-DataUpgradeToFinish -ServerInstance BC 
 
                 Write-Host    "Check data upgrade is executed"
                 Set-NavServerInstance -ServerInstance BC -Restart

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -123,7 +123,7 @@ function Import-AppArtifact {
             }
 
             # Sync NAVApp
-            if ($success -and $env:cosmoHasTenant) {
+            if ($success -and ($env:cosmoHasTenant -eq "true")) {
                 $skipInstall = ! $success
                 try {
                     $started2 = Get-Date -Format "o"
@@ -144,7 +144,7 @@ function Import-AppArtifact {
             }
 
             # Check for Data Upgrade
-            if ((! $skipInstall) -and ($runDataUpgrade) -and ($env:cosmoHasTenant)) {
+            if ((! $skipInstall) -and ($runDataUpgrade) -and ($env:cosmoHasTenant -eq "true")) {
                 try {
                     $started2 = Get-Date -Format "o"
                     Add-ArtifactsLog -kind App -message "Start App Data Upgrade $($app.Name) $($app.Publisher) $($app.Version)..." -data $app
@@ -168,7 +168,7 @@ function Import-AppArtifact {
             }
 
             # Install NAVApp
-            if (! $skipInstall -and $env:cosmoHasTenant) {
+            if (! $skipInstall -and $env:cosmoHasTenant -eq "true") {
                 try {
                     $started3 = Get-Date -Format "o"
                     Add-ArtifactsLog -kind App -message "Install App $($app.Name) $($app.Publisher) $($app.Version)..." -data $app
@@ -193,7 +193,7 @@ function Import-AppArtifact {
             }
 
             # Check Result
-            if ($env:cosmoHasTenant) {
+            if ($env:cosmoHasTenant -eq "true") {
                 $result = Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -Version $app.Version -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue
                 if ($result) { 
                     Add-ArtifactsLog -kind App -message "$(($result | Select-Object Name, Publisher, Version, IsPublished, IsInstalled, SyncState, NeedsUpgrade, ExtensionDataVersion | Format-Table -AutoSize | Out-String -Width 1024).Trim())"

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -190,6 +190,13 @@ function Import-AppArtifact {
             if ($IsModifiedBaseApp) {
                 Write-Host "Set application version to $($app.Version) as this is a modified base app"
                 Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
+                Sync-NAVTenant -ServerInstance BC -Mode Sync -Force -ErrorAction Stop
+                Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Stop 
+                Wait-DataUpgradeToFinish -ServerInstance BC -ErrorAction Stop 
+
+                Write-Host    "Check data upgrade is executed"
+                Set-NavServerInstance -ServerInstance BC -Restart
+                Check-DataUpgradeExecuted -ServerInstance BC -RequiredTenantDataVersion "$($app.Version)"
             }
 
             # Check Result

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -4,6 +4,7 @@ function Import-AppArtifact {
         [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
         [Alias("FullName")]    
         [string]$Path,
+        [switch]$IsModifiedBaseApp,
         [Parameter(Mandatory=$false)]
         [string]$ServerInstance = "NAV",
         [Parameter(Mandatory=$false)]
@@ -184,6 +185,13 @@ function Import-AppArtifact {
                     Invoke-LogOperation -name "Install App" -started $started3 -properties $properties -success $success -telemetryClient $telemetryClient
                 }
             }
+
+            # Special handling for modified base app
+            if ($IsModifiedBaseApp) {
+                Write-Host "Set application version to $($app.Version) as this is a modified base app"
+                Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
+            }
+
             # Check Result
             $result = Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -Version $app.Version -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue
             if ($result) { 

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -188,18 +188,8 @@ function Import-AppArtifact {
 
             # Special handling for modified base app
             if ($IsModifiedBaseApp) {
-                Write-Host "Set application version to $($app.Version) as this is a modified base app"
-                Set-NAVApplication -ApplicationVersion "$($app.Version)" -ServerInstance BC -Force -ErrorAction Stop
-                Write-Host "Sync tenant"
-                Sync-NAVTenant -ServerInstance BC -Mode Sync -Force
-                Write-Host "Start data upgrade"
-                Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force
-                Write-Host "Wait for data upgrade to finish"
-                Wait-DataUpgradeToFinish -ServerInstance BC 
-
-                Write-Host    "Check data upgrade is executed"
-                Set-NavServerInstance -ServerInstance BC -Restart
-                Check-DataUpgradeExecuted -ServerInstance BC -RequiredTenantDataVersion "$($app.Version)"
+                # remember base app version
+                $env:cosmoBaseAppVersion = $app.Version
             }
 
             # Check Result

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -123,7 +123,7 @@ function Import-AppArtifact {
             }
 
             # Sync NAVApp
-            if ($success) {
+            if ($success -and $env:cosmoHasTenant) {
                 $skipInstall = ! $success
                 try {
                     $started2 = Get-Date -Format "o"
@@ -144,7 +144,7 @@ function Import-AppArtifact {
             }
 
             # Check for Data Upgrade
-            if ((! $skipInstall) -and ($runDataUpgrade)) {
+            if ((! $skipInstall) -and ($runDataUpgrade) -and ($env:cosmoHasTenant)) {
                 try {
                     $started2 = Get-Date -Format "o"
                     Add-ArtifactsLog -kind App -message "Start App Data Upgrade $($app.Name) $($app.Publisher) $($app.Version)..." -data $app
@@ -168,7 +168,7 @@ function Import-AppArtifact {
             }
 
             # Install NAVApp
-            if (! $skipInstall) {
+            if (! $skipInstall -and $env:cosmoHasTenant) {
                 try {
                     $started3 = Get-Date -Format "o"
                     Add-ArtifactsLog -kind App -message "Install App $($app.Name) $($app.Publisher) $($app.Version)..." -data $app
@@ -193,24 +193,26 @@ function Import-AppArtifact {
             }
 
             # Check Result
-            $result = Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -Version $app.Version -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue
-            if ($result) { 
-                Add-ArtifactsLog -kind App -message "$(($result | Select-Object Name, Publisher, Version, IsPublished, IsInstalled, SyncState, NeedsUpgrade, ExtensionDataVersion | Format-Table -AutoSize | Out-String -Width 1024).Trim())"
-                $result = $result | Select-Object -First 1
-                Add-ArtifactsLog -kind App -message "App Status $($app.Name) $($app.Publisher) $($app.Version) ... Published: $($result.IsPublished) Installed: $($result.IsInstalled) SyncState: $($result.SyncState) " -data $result
-            } else {
-                Add-ArtifactsLog -kind App -message "Import App $($app.Name) $($app.Publisher) $($app.Version) failed" -data $app -severity Error -success fail
-            }
+            if ($env:cosmoHasTenant) {
+                $result = Get-NAVAppInfo -ServerInstance $ServerInstance -Name $app.Name -Publisher $app.Publisher -Version $app.Version -TenantSpecificProperties -Tenant $Tenant -ErrorAction SilentlyContinue
+                if ($result) { 
+                    Add-ArtifactsLog -kind App -message "$(($result | Select-Object Name, Publisher, Version, IsPublished, IsInstalled, SyncState, NeedsUpgrade, ExtensionDataVersion | Format-Table -AutoSize | Out-String -Width 1024).Trim())"
+                    $result = $result | Select-Object -First 1
+                    Add-ArtifactsLog -kind App -message "App Status $($app.Name) $($app.Publisher) $($app.Version) ... Published: $($result.IsPublished) Installed: $($result.IsInstalled) SyncState: $($result.SyncState) " -data $result
+                } else {
+                    Add-ArtifactsLog -kind App -message "Import App $($app.Name) $($app.Publisher) $($app.Version) failed" -data $app -severity Error -success fail
+                }
 
-            if ($result) {
-                $properties["IsPublished"]          = $result.IsPublished
-                $properties["IsInstalled"]          = $result.IsInstalled
-                $properties["SyncState"]            = $result.SyncState
-                $properties["NeedsUpgrade"]         = $result.NeedsUpgrade
-                $properties["ExtensionDataVersion"] = $result.ExtensionDataVersion
+                if ($result) {
+                    $properties["IsPublished"]          = $result.IsPublished
+                    $properties["IsInstalled"]          = $result.IsInstalled
+                    $properties["SyncState"]            = $result.SyncState
+                    $properties["NeedsUpgrade"]         = $result.NeedsUpgrade
+                    $properties["ExtensionDataVersion"] = $result.ExtensionDataVersion
+                }
+                Add-ArtifactsLog -message " "
+                Invoke-LogOperation -name "Import App Artifact" -started $started -properties $properties -telemetryClient $telemetryClient
             }
-            Add-ArtifactsLog -message " "
-            Invoke-LogOperation -name "Import App Artifact" -started $started -properties $properties -telemetryClient $telemetryClient
         }
         catch {
             Invoke-LogError -exception $_.Exception -telemetryClient $telemetryClient -properties $properties -operation "Import App Artifact"

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -83,7 +83,7 @@ function Import-Artifacts {
                 Write-Host "Import $($items.Length) Apps..."
                 
                 Add-ArtifactsLog -message "Install Apps:$([System.Environment]::NewLine)$($items | Format-Table -AutoSize -Wrap:$false | Out-String -Width 1024)" -data $app
-
+                
                 # Import all Apps
                 foreach ($item in $items) {
                     # Try to Find the App-Specific Import Scope stored during download in "artifact.json" (Global setup is used, when no app specific information are present in the parent folders)

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -94,8 +94,10 @@ function Import-Artifacts {
                             $importScope = $artifactJson.appImportScope
                         }
                     }
+
+                    $IsModifiedBaseApp = $item.Path.IndexOf("sortorder01") -gt -1
                         
-                    @($item) | Import-AppArtifact -ServerInstance $ServerInstance -Tenant default -Scope $importScope -SyncMode $SyncMode -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+                    @($item) | Import-AppArtifact -ServerInstance $ServerInstance -Tenant default -Scope $importScope -SyncMode $SyncMode -telemetryClient $telemetryClient -ErrorAction SilentlyContinue -IsModifiedBaseApp:$IsModifiedBaseApp
                 }                
 
                 $properties["files"] = ($items | ForEach-Object { $_.FullName } | ConvertTo-Json -ErrorAction SilentlyContinue)

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -72,19 +72,11 @@ function Import-Artifacts {
             Write-Host ("Found App expression override {0}" -f $env:AppExcludeExpr)
             $params.Add("ExcludeExpr", $env:AppExcludeExpr)   
         }
-        <#if ($Path.StartsWith("C:\run\my\manuallysorted-apps")) {
-            Write-Host "Working on manually sorted apps"
-            $items = Get-ChildItem -LiteralPath "$Path" -recurse -filter "*.app"
-            foreach ($item in $items) {
-                $item.Path = $item.FullName
-            }
-        } else {#>
-            if (Test-Path -LiteralPath "$Path") {
-                $params.Add("Path", "$Path")
-                Write-Host "Working on apps sorted by dependency"
-                $items = @() + (Get-AppFilesSortedByDependencies @params -ErrorAction SilentlyContinue)
-            }
-        #}
+        if (Test-Path -LiteralPath "$Path") {
+            $params.Add("Path", "$Path")
+            Write-Host "Working on apps sorted by dependency"
+            $items = @() + (Get-AppFilesSortedByDependencies @params -ErrorAction SilentlyContinue)
+        }
         if ($items) {
             try {
                 $started   = Get-Date -Format "o"

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -72,9 +72,15 @@ function Import-Artifacts {
             Write-Host ("Found App expression override {0}" -f $env:AppExcludeExpr)
             $params.Add("ExcludeExpr", $env:AppExcludeExpr)   
         }
-        if (Test-Path -LiteralPath "$Path") {
-            $params.Add("Path", "$Path")
-            $items = @() + (Get-AppFilesSortedByDependencies @params -ErrorAction SilentlyContinue)
+        if ($Path.StartsWith("C:\run\my\manuallysorted-apps")) {
+            Write-Host "Working on manually sorted apps"
+            $items = Get-ChildItem -LiteralPath "$Path" -recurse
+        } else {
+            if (Test-Path -LiteralPath "$Path") {
+                $params.Add("Path", "$Path")
+                Write-Host "Working on apps sorted by dependency"
+                $items = @() + (Get-AppFilesSortedByDependencies @params -ErrorAction SilentlyContinue)
+            }
         }
         if ($items) {
             try {
@@ -82,7 +88,7 @@ function Import-Artifacts {
                 Write-Host "Import $($items.Length) Apps..."
                 
                 Add-ArtifactsLog -message "Install Apps:$([System.Environment]::NewLine)$($items | Format-Table -AutoSize -Wrap:$false | Out-String -Width 1024)" -data $app
-                
+
                 # Import all Apps
                 foreach ($item in $items) {
                     # Try to Find the App-Specific Import Scope stored during download in "artifact.json" (Global setup is used, when no app specific information are present in the parent folders)

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -72,16 +72,19 @@ function Import-Artifacts {
             Write-Host ("Found App expression override {0}" -f $env:AppExcludeExpr)
             $params.Add("ExcludeExpr", $env:AppExcludeExpr)   
         }
-        if ($Path.StartsWith("C:\run\my\manuallysorted-apps")) {
+        <#if ($Path.StartsWith("C:\run\my\manuallysorted-apps")) {
             Write-Host "Working on manually sorted apps"
             $items = Get-ChildItem -LiteralPath "$Path" -recurse -filter "*.app"
-        } else {
+            foreach ($item in $items) {
+                $item.Path = $item.FullName
+            }
+        } else {#>
             if (Test-Path -LiteralPath "$Path") {
                 $params.Add("Path", "$Path")
                 Write-Host "Working on apps sorted by dependency"
                 $items = @() + (Get-AppFilesSortedByDependencies @params -ErrorAction SilentlyContinue)
             }
-        }
+        #}
         if ($items) {
             try {
                 $started   = Get-Date -Format "o"

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -74,7 +74,7 @@ function Import-Artifacts {
         }
         if ($Path.StartsWith("C:\run\my\manuallysorted-apps")) {
             Write-Host "Working on manually sorted apps"
-            $items = Get-ChildItem -LiteralPath "$Path" -recurse
+            $items = Get-ChildItem -LiteralPath "$Path" -recurse -filter "*.app"
         } else {
             if (Test-Path -LiteralPath "$Path") {
                 $params.Add("Path", "$Path")

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifact.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifact.ps1
@@ -165,7 +165,11 @@ function Invoke-DownloadArtifact {
                     # Setup correct folder
                     $folderIdx = $folderIdx + 1
                     if ("$targetFolder" -eq "") {
-                        $folderSuffix = "$($folderIdx.ToString().PadLeft(3, '0'))"                        
+                        if ($name.StartsWith("sortorder")) {
+                            $folderSuffix = $name.Split(" ")[0]
+                        } else {
+                            $folderSuffix = "$($folderIdx.ToString().PadLeft(3, '0'))"                        
+                        }
                     } else {
                         $folderSuffix = "$targetFolder"
                     }


### PR DESCRIPTION
To work with modified base apps, 3 things needed to happen:

1. The modified base app and immediately after that, the Application app must be published and installed. I've solved this by adding a prefix of "sortorderXX" like "sortorder01" to the name and handling those artifact in a special way
2. When the modified base app is imported, the NAV Application Version must be set as well. As I already had 1., I solved this by looking for sortorder01
5. For 4PS, the embed clusters in BC Online work with a different collation, so the restored tenant database comes with that collation. To fix that, the app database is exported, a new empty database is created and the app database is imported again

Additionally, but not necessarily connected to a modified base app: On SaaS, we might have more than the 150 full users that are typically included in a dev license. Therefore, all users (except the user of the requesting person) are disabled
