### PR TITLE
Just install latest version

### DIFF
--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -64,10 +64,20 @@ function Get-AppFilesSortedByDependencies {
         $AllApps = [System.Collections.ArrayList]@()
         foreach ($AppFile in $AllAppFiles) {
             try {
+                Write-Host "Processing $($AppFile.FullName)"
                 $App = Get-NAVAppInfo -Path $AppFile.FullName 
                 if ($Distinct) {
-                    $olderApps = ($AllApps | where { $App.AppId -eq $_.AppId -and [System.Version]::Parse($App.Version) -ge [System.Version]::Parse($_.Version) })
-                    foreach ($olderApp in $olderApps) { $AllApps.Remove($olderApp) }                    
+                    $equalApp = ($AllApps | Where-Object { $App.AppId -eq $_.AppId })
+                    if($null -ne $equalApp){
+                        Write-Host "Found equal app"
+                        if([System.Version]::Parse($App.Version) -gt [System.Version]::Parse($equalApp.Version)){
+                            Write-Host "Removed version $($equalApp.Version) as $($App.Version) is greater."
+                            $AllApps.Remove($equalApp)
+                        } else {
+                            Write-Host "Existing version $($equalApp.version) is greater than or equal to $($App.Version). Skipping this one."
+                            continue;
+                        }
+                    }
                 }
                 $AllApps.Add([PSCustomObject]@{
                     AppId        = $App.AppId


### PR DESCRIPTION
Ich hatte ein Szenario mit folgenden Dateien:
C:\run\my\apps\001\Microsoft_Tests-TestLibraries_23.1.13431.15855.app
C:\run\my\apps\002\Microsoft_Tests-TestLibraries_23.1.13431.15855.app
C:\run\my\apps\015\Microsoft_Tests-TestLibraries.app

Aktuell prüft die forEach Schleife nur, ob bestehende Apps in der Liste sind, die eine kleinere Versionsnr. haben. Ist das der Fall, werden sie gelöscht.
Wenn eine App mit einer kleineren Versionsnr. erst später bearbeitet wird (da der Dateiname nicht die Versionsnr. hinten angefügt hat). wird die App einfach hinzugefügt. Deshalb wurde in meinem Fall die C:\run\my\apps\015\Microsoft_Tests-TestLibraries.app auch gepublished, welche fehlerhaft war und gar nicht installiert werden sollte.