### PR TITLE
chore(logging): ignore error when last user is deactivated

### DIFF
--- a/base/my/SetupNavUsers.ps1
+++ b/base/my/SetupNavUsers.ps1
@@ -17,7 +17,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrWhiteSpace($en
     Write-Host " - Deactivate all users to ensure license compliance"
     Get-NAVServerUser -ServerInstance $ServerInstance | Where-Object { $_.UserName.ToLower() -ne $env:username.ToLower() } | % {
         Write-Host " - Disable $($_.UserName)"
-        Set-NAVServerUser -UserName $_.UserName -State Disabled -ServerInstance $ServerInstance -ErrorAction Continue
+        Set-NAVServerUser -UserName $_.UserName -State Disabled -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
     }
 }
 


### PR DESCRIPTION
When deactivating users in a restored bak to ensure license compliance, the last user gets an error message:

```
 - Deactivate all users to ensure license compliance
 - Disable ADMIN
Set-NAVServerUser : There should be at least one enabled 'SUPER' user.
At C:\Run\my\SetupNavUsers.ps1:20 char:9
+         Set-NAVServerUser -UserName $_.UserName -State Disabled -Serv ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (0:Int32) [Set-NAVServerUser], Fau 
   ltException`1
    + FullyQualifiedErrorId : MicrosoftDynamicsNavServer$BC,Microsoft.Dynamics 
   .Nav.Management.Cmdlets.SetNavServerUser
```

This doesn't matter because we create a NAV user immediately afterwards, but Alpaca users sometimes are irritated by this error message. Therefore, I would like to hide it