### PR TITLE
feat(saas-bak): extendable excludeAppsFromSaaSBak, improve additional setup and data upgrade

### DIFF
--- a/artifacts/4PS/Wait-DataUpgradeToFinish.ps1
+++ b/artifacts/4PS/Wait-DataUpgradeToFinish.ps1
@@ -23,24 +23,20 @@ function Wait-DataUpgradeToFinish {
         if (!$Tenant) { $Tenant = 'default' }
         
         try {      
-            do {
-                Start-Sleep -Seconds 1 | Out-Null
-                $status = Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $Tenant
-            } while ( "$($status.State)" -in @("InProgress") )
+            Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $tenant -Progress
         }
         catch { 
-            Write-Host "Couldn't get the status of the NAVDataUpgrade, maybe none is running"
+            Write-Host "Couldn't get the progress of the NAVDataUpgrade, maybe none is running"
         }
 
         try {
             $errors = Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $Tenant -ErrorOnly
-            $errorsString = $errors | Out-String
         }
         catch { 
             Write-Host "Couldn't get the errors of the NAVDataUpgrade, maybe none is running"
         }
     
-        if (!$errors -and ("$($status.NumericProgress)" -eq 1)) {
+        if (!$errors) {
             Write-Host "no errors detected - process has been completed successfully"
             return;
         }
@@ -54,7 +50,7 @@ function Wait-DataUpgradeToFinish {
         }
 
         $errorMessage = "Errors occurred during the NAVDataUpgrade process: " + [System.Environment]::NewLine
-        $errorsString.Trim().Replace("`r`n", "`n").Split("`n") | ForEach-Object { $errorMessage += $_ + [System.Environment]::NewLine }
+        ($errors | Out-String).Trim().Replace("`r`n", "`n").Split("`n") | ForEach-Object { $errorMessage += $_ + [System.Environment]::NewLine }
         Write-Host $errorMessage
     }
 }

--- a/artifacts/4PS/Wait-DataUpgradeToFinish.ps1
+++ b/artifacts/4PS/Wait-DataUpgradeToFinish.ps1
@@ -20,44 +20,41 @@ function Wait-DataUpgradeToFinish {
         [string]$Tenant
     )
     PROCESS {
-        if (!$Tenant) {
-            $Tenant = 'default'
-        }
-
-        try {
-            Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $tenant -Progress
+        if (!$Tenant) { $Tenant = 'default' }
+        
+        try {      
+            do {
+                Start-Sleep -Seconds 1 | Out-Null
+                $status = Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $Tenant
+            } while ( "$($status.State)" -in @("InProgress") )
         }
         catch { 
-            Write-Host "Couldn't get the progress of the NAVDataUpgrade, maybe none is running"
+            Write-Host "Couldn't get the status of the NAVDataUpgrade, maybe none is running"
         }
 
         try {
-            # Make sure that Upgrade Process completed successfully.
-            $errors = Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $tenant -ErrorOnly
+            $errors = Get-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $Tenant -ErrorOnly
+            $errorsString = $errors | Out-String
         }
         catch { 
             Write-Host "Couldn't get the errors of the NAVDataUpgrade, maybe none is running"
         }
     
-        if (!$errors) {
-
+        if (!$errors -and ("$($status.NumericProgress)" -eq 1)) {
             Write-Host "no errors detected - process has been completed successfully"
             return;
         }
 
         # Stop the suspended process
         try {
-            Stop-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $tenant -Force
+            Stop-NAVDataUpgrade -ServerInstance $ServerInstance -Tenant $Tenant -Force
         }
         catch { 
             Write-Host "Couldn't stop the NAVDataUpgrade, maybe none is running"
         }
 
-        $errorMessage = "Errors occurred during the Microsoft Dynamics NAV data upgrade process: " + [System.Environment]::NewLine
-        foreach ($nextErrorRecord in $errors) {
-            $errorMessage += ("Codeunit ID: " + $nextErrorRecord.CodeunitId + ", Function: " + $nextErrorRecord.FunctionName + ", Error: " + $nextErrorRecord.Error + ", Company: " + $nextErrorRecord.CompanyName + [System.Environment]::NewLine)
-        }
-
+        $errorMessage = "Errors occurred during the NAVDataUpgrade process: " + [System.Environment]::NewLine
+        $errorsString.Trim().Replace("`r`n", "`n").Split("`n") | ForEach-Object { $errorMessage += $_ + [System.Environment]::NewLine }
         Write-Host $errorMessage
     }
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -413,7 +413,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
     Write-Host " - Syncing all apps"
     for ($i = 0; $i -lt 10; $i++) {
-        Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+        Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" } | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
     }
 
     Write-Host " - Upgrading all apps"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -310,7 +310,7 @@ if ($enablePerformanceCounter.ToLower() -eq "true") {
     }
 }
 
-$blackListedApps = @(
+$excludeAppsFromSaaSBak = @(
     [pscustomobject]@{
         Name   = "CKL Monetization";
         Id     = '2d648cd3-1779-449a-b0eb-23a98267d85e';
@@ -322,11 +322,8 @@ $blackListedApps = @(
         Reason = "works only on SaaS"
     }
 )
-if ($env:blackListedAppsJson) {
-    $blackListedAppsJson = $env:blackListedAppsJson | ConvertFrom-Json
-    if ($blackListedAppsJson -is [array] -and $blackListedAppsJson.Length -gt 0) {
-        $blackListedApps += $blackListedAppsJson
-    }
+if ($global:excludeAppsFromSaaSBak -is [array] -and $global:excludeAppsFromSaaSBak.Length -gt 0) {
+    $excludeAppsFromSaaSBak += $global:excludeAppsFromSaaSBak
 }
 
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile)) {
@@ -357,10 +354,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Invoke-Sqlcmd -Database $tenantId -Query "UPDATE [dbo].[NAV App Installed App] SET [Package ID] = '$($app.'Package ID')' WHERE [App ID] = '$($app.'App ID')'" -ServerInstance "$DatabaseServer\$DatabaseInstance"
     }
 
-    foreach ($blackListedApp in $blackListedApps) {
-        Write-Host "   - Removing app '$($blackListedApp.Name)' if installed, reason '$($blackListedApp.Reason)', id '$($blackListedApp.Id)'"
-        Invoke-Sqlcmd -Database $tenantId -Query "DELETE FROM [dbo].[NAV App Published App] WHERE [App ID] = '$($blackListedApp.Id)'" -ServerInstance "$DatabaseServer\$DatabaseInstance"
-        Invoke-Sqlcmd -Database $tenantId -Query "DELETE FROM [dbo].[NAV App Installed App] WHERE [App ID] = '$($blackListedApp.Id)'" -ServerInstance "$DatabaseServer\$DatabaseInstance"
+    foreach ($excludeApp in $excludeAppsFromSaaSBak) {
+        Write-Host "   - Removing app '$($excludeApp.Name)' if installed, reason '$($excludeApp.Reason)', id '$($excludeApp.Id)'"
+        Invoke-Sqlcmd -Database $tenantId -Query "DELETE FROM [dbo].[NAV App Published App] WHERE [App ID] = '$($excludeApp.Id)'" -ServerInstance "$DatabaseServer\$DatabaseInstance"
+        Invoke-Sqlcmd -Database $tenantId -Query "DELETE FROM [dbo].[NAV App Installed App] WHERE [App ID] = '$($excludeApp.Id)'" -ServerInstance "$DatabaseServer\$DatabaseInstance"
     }
 
     Write-Host " - Replacing default tenant database with new SaaS database"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -178,7 +178,7 @@ catch {
 }
 finally {
     # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
-    $artifactsRequireRestart = $artifacts | Where-Object { $_ -and $_.target -and ($_.target.ToLower() -eq "dll" -or $_.target.ToLower() -eq "add-ins") }
+    $artifactsRequireRestart = $artifacts | Where-Object { ($_.target ?? "").ToLower() -eq "dll" -or ($_.target ?? "").ToLower() -eq "add-ins" }
     if ($artifactsRequireRestart -and $artifactsRequireRestart.Count -gt 0) {
         Write-Host "Restart NAV service to load new DLLs/Add-ins"
         Restart-Service -Name $NavServiceName

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,23 +412,15 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    $i = 0
     do {
-        $i++
         $unsyncedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" }
-        Write-Host " - - Sync $($unsyncedApps.Count) apps in loop $i..."
         $unsyncedApps | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-        Write-Host " - - Loop $i done"
     } while ($unsyncedApps.Count -gt 0)
 
     Write-Host " - Upgrading all apps"
-    $i = 0
     do {
-        $i++
         $upgradeableApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" }
-        Write-Host " - - Upgrading $($upgradeableApps.Count) apps in loop $i..."
         $upgradeableApps | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue
-        Write-Host " - - Loop $i done"
     } while ($upgradeableApps.Count -gt 0)
 
     Write-Host " - Syncing new tenant"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -177,21 +177,6 @@ catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error
 }
 finally {
-    # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
-    if (@($artifacts | Where-Object { "$($_.target)".ToLower() -eq "dll" -or "$($_.target)".ToLower() -eq "add-ins" }).Count -gt 0) {
-        Write-Host "Restart NAV service to load new DLLs/Add-ins"
-        Restart-Service -Name $NavServiceName
-        for ($i = 0; $i -lt 10; $i++) {
-            $TenantState = (Get-NavTenant -ServerInstance $NavServiceName -Tenant $TenantId).State
-            if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
-                break;
-            }
-
-            Write-Host " - - Tenant not operational yet (try $i), sleeping 10s"
-            Start-Sleep -Seconds 10
-        }
-    }
-
     Add-ArtifactsLog -message "Download Artifacts done."
     Write-Host "##[endgroup]"
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -322,8 +322,9 @@ $blackListedApps = @(
         Reason = "works only on SaaS"
     }
 )
-if ($env:blackListedApps -and $env:blackListedApps.Count -gt 0) {
-    $blackListedApps += $env:blackListedApps
+if ($env:blackListedAppsJson) {
+    $blackListedAppsJson = $env:blackListedAppsJson | ConvertFrom-Json
+    $blackListedApps += $blackListedAppsJson
 }
 
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile)) {

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,10 +412,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -AppId $_.AppId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Upgrading all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -AppId $_.AppId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -166,7 +166,7 @@ try {
     Write-Host "##[group]Download Artifacts"
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))) } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { "$($_.target)".ToLower() -ne "bak" -and "$($_.target)".ToLower() -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))) } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder") } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
@@ -178,7 +178,7 @@ catch {
 }
 finally {
     # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
-    $artifactsRequireRestart = $artifacts | Where-Object { $_.target -ne $null -and ($_.target.ToLower() -eq "dll" -or $_.target.ToLower() -eq "add-ins") }
+    $artifactsRequireRestart = $artifacts | Where-Object { "$($_.target)".ToLower() -eq "dll" -or "$($_.target)".ToLower() -eq "add-ins" }
     if ($artifactsRequireRestart -and $artifactsRequireRestart.Count -gt 0) {
         Write-Host "Restart NAV service to load new DLLs/Add-ins"
         Restart-Service -Name $NavServiceName

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -413,7 +413,13 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
     Write-Host " - Syncing all apps"
     for ($i = 0; $i -lt 10; $i++) {
-        Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" } | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+        $unsyncedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" }
+        Write-Host " - - Found $($unsyncedApps.Count) unsynced apps in loop $i"
+        foreach ($app in $unsyncedApps) {
+            Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+            Write-Host " - - Synced $($app.Name) in loop $i"
+        }
+        Write-Host " - - Loop $i done"
     }
 
     Write-Host " - Upgrading all apps"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -178,7 +178,7 @@ catch {
 }
 finally {
     # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
-    $artifactsRequireRestart = $artifacts | Where-Object { ($_.target ?? "").ToLower() -eq "dll" -or ($_.target ?? "").ToLower() -eq "add-ins" }
+    $artifactsRequireRestart = $artifacts | Where-Object { $_.target -ne $null -and ($_.target.ToLower() -eq "dll" -or $_.target.ToLower() -eq "add-ins") }
     if ($artifactsRequireRestart -and $artifactsRequireRestart.Count -gt 0) {
         Write-Host "Restart NAV service to load new DLLs/Add-ins"
         Restart-Service -Name $NavServiceName

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -417,14 +417,14 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     while ($unsyncedApps.Count -gt 0) {
         Write-Host " - - Found $($unsyncedApps.Count) unsynced apps in loop $i"
         
-        foreach ($app in $unsyncedApps) {
+        $unsyncedApps | ForEach-Object {
             Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
-            Write-Host " - - Synced $($app.Name) in loop $i"
+            Write-Host " - - Synced $($_.Name) in loop $i"
         }
         
         $unsyncedApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" })
-        $i++
         Write-Host " - - Loop $i done"
+        $i++
     }
 
     Write-Host " - Upgrading all apps"
@@ -432,15 +432,15 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     $i = 1
     while ($upgradeableApps.Count -gt 0) {
         Write-Host " - - Found $($upgradeableApps.Count) upgradeable apps in loop $i"
-        
-        foreach ($app in $upgradeableApps) {
+
+        $upgradeableApps | ForEach-Object {
             Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
-            Write-Host " - - Upgraded $($app.Name) in loop $i"
+            Write-Host " - - Upgraded $($_.Name) in loop $i"
         }
         
         $upgradeableApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" })
-        $i++
         Write-Host " - - Loop $i done"
+        $i++
     }
 
     Write-Host " - Syncing new tenant"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,12 +412,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    for ($i = 0; $i -lt 10; $i++) {
-        Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
-    }
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -AppId $_.AppId -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Upgrading all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -AppId $_.AppId -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -418,6 +418,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         $unsyncedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" }
         Write-Host " - - Sync $($unsyncedApps.Count) apps in loop $i..."
         $unsyncedApps | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+        Write-Host " - - Loop $i done"
     } while ($unsyncedApps.Count -gt 0)
 
     Write-Host " - Upgrading all apps"
@@ -425,8 +426,9 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     do {
         $i++
         $upgradeableApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" }
-        Write-Host " - - Upgrading $($unsyncedApps.Count) apps in loop $i..."
+        Write-Host " - - Upgrading $($upgradeableApps.Count) apps in loop $i..."
         $upgradeableApps | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue
+        Write-Host " - - Loop $i done"
     } while ($upgradeableApps.Count -gt 0)
 
     Write-Host " - Syncing new tenant"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -178,8 +178,7 @@ catch {
 }
 finally {
     # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
-    $artifactsRequireRestart = $artifacts | Where-Object { "$($_.target)".ToLower() -eq "dll" -or "$($_.target)".ToLower() -eq "add-ins" }
-    if ($artifactsRequireRestart -and $artifactsRequireRestart.Count -gt 0) {
+    if (@($artifacts | Where-Object { "$($_.target)".ToLower() -eq "dll" -or "$($_.target)".ToLower() -eq "add-ins" }).Count -gt 0) {
         Write-Host "Restart NAV service to load new DLLs/Add-ins"
         Restart-Service -Name $NavServiceName
         for ($i = 0; $i -lt 10; $i++) {

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -182,7 +182,7 @@ finally {
         Write-Host "Restart NAV service to load new DLLs/Add-ins"
         Restart-Service -Name $NavServiceName
         for ($i = 0; $i -lt 10; $i++) {
-            $TenantState = (Get-NavTenant -ServerInstance $NavServiceName -Tenant $Tenant).State
+            $TenantState = (Get-NavTenant -ServerInstance $NavServiceName -Tenant $TenantId).State
             if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
                 break;
             }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,26 +412,22 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    $unsyncedApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" })
     $i = 0
-    while ($unsyncedApps.Count -gt 0) {
+    do {
         $i++
-        Write-Host " - - Found $($unsyncedApps.Count) unsynced apps in loop $i"
-        $unsyncedApps | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
-        $unsyncedApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" })
-        Write-Host " - - Loop $i done"
-    }
+        $unsyncedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" }
+        Write-Host " - - Sync $($unsyncedApps.Count) apps in loop $i..."
+        $unsyncedApps | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+    } while ($unsyncedApps.Count -gt 0)
 
     Write-Host " - Upgrading all apps"
-    $upgradeableApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" })
     $i = 0
-    while ($upgradeableApps.Count -gt 0) {
+    do {
         $i++
-        Write-Host " - - Found $($upgradeableApps.Count) upgradeable apps in loop $i"
-        $upgradeableApps | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
-        $upgradeableApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" })
-        Write-Host " - - Loop $i done"
-    }
+        $upgradeableApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" }
+        Write-Host " - - Upgrading $($unsyncedApps.Count) apps in loop $i..."
+        $upgradeableApps | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction SilentlyContinue
+    } while ($upgradeableApps.Count -gt 0)
 
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -177,6 +177,21 @@ catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error
 }
 finally {
+    # if there are any "dll" or "add-ins" artifacts we need to restart the service (fonts are handled individually)
+    if ($artifacts -and ($artifacts | Where-Object { $_.target.ToLower() -eq "dll" -or $_.target.ToLower() -eq "add-ins" }).Count -gt 0) {
+        Write-Host "Restart NAV service to load new DLLs/Add-ins"
+        Restart-Service -Name $NavServiceName
+        for ($i = 0; $i -lt 10; $i++) {
+            $TenantState = (Get-NavTenant -ServerInstance $NavServiceName -Tenant $Tenant).State
+            if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
+                break;
+            }
+
+            Write-Host " - - Tenant not operational yet (try $i), sleeping 10s"
+            Start-Sleep -Seconds 10
+        }
+    }
+
     Add-ArtifactsLog -message "Download Artifacts done."
     Write-Host "##[endgroup]"
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -424,7 +424,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Upgrading tenant"
-    Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Continue -Tenant $TenantId
+    Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Stop -Tenant $TenantId
     Wait-DataUpgradeToFinish -ServerInstance BC -ErrorAction Stop -Tenant $TenantId
 
     Write-Host " - Check data upgrade is executed"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -324,7 +324,9 @@ $blackListedApps = @(
 )
 if ($env:blackListedAppsJson) {
     $blackListedAppsJson = $env:blackListedAppsJson | ConvertFrom-Json
-    $blackListedApps += $blackListedAppsJson
+    if ($blackListedAppsJson -is [array] -and $blackListedAppsJson.Length -gt 0) {
+        $blackListedApps += $blackListedAppsJson
+    }
 }
 
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile)) {

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -413,34 +413,24 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
 
     Write-Host " - Syncing all apps"
     $unsyncedApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" })
-    $i = 1
+    $i = 0
     while ($unsyncedApps.Count -gt 0) {
+        $i++
         Write-Host " - - Found $($unsyncedApps.Count) unsynced apps in loop $i"
-        
-        $unsyncedApps | ForEach-Object {
-            Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -ErrorAction silentlycontinue -WarningAction silentlycontinue
-            Write-Host " - - Synced $($_.Name) in loop $i"
-        }
-        
+        $unsyncedApps | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
         $unsyncedApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.SyncState -ne "Synced" })
         Write-Host " - - Loop $i done"
-        $i++
     }
 
     Write-Host " - Upgrading all apps"
     $upgradeableApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" })
-    $i = 1
+    $i = 0
     while ($upgradeableApps.Count -gt 0) {
+        $i++
         Write-Host " - - Found $($upgradeableApps.Count) upgradeable apps in loop $i"
-
-        $upgradeableApps | ForEach-Object {
-            Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -ErrorAction silentlycontinue
-            Write-Host " - - Upgraded $($_.Name) in loop $i"
-        }
-        
+        $upgradeableApps | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
         $upgradeableApps = @(Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId -TenantSpecificProperties | Where-Object { $_.NeedsUpgrade -eq "True" })
         Write-Host " - - Loop $i done"
-        $i++
     }
 
     Write-Host " - Syncing new tenant"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -430,7 +430,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
     Write-Host " - Check data upgrade is executed"
     Set-NavServerInstance -ServerInstance BC -Restart
     
-    for ($i = 0; $i -lt 10; $i++) {
+    for ($i = 0; $i -lt 20; $i++) {
         $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
         if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
             break;

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,10 +412,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -Force -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Upgrading all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -Force -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
 
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -418,7 +418,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host " - - Found $($unsyncedApps.Count) unsynced apps in loop $i"
         
         $unsyncedApps | ForEach-Object {
-            Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+            Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -ErrorAction silentlycontinue -WarningAction silentlycontinue
             Write-Host " - - Synced $($_.Name) in loop $i"
         }
         
@@ -434,7 +434,7 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         Write-Host " - - Found $($upgradeableApps.Count) upgradeable apps in loop $i"
 
         $upgradeableApps | ForEach-Object {
-            Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue
+            Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -ErrorAction silentlycontinue
             Write-Host " - - Upgraded $($_.Name) in loop $i"
         }
         

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,7 +412,9 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    for ($i = 0; $i -lt 10; $i++) {
+        Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    }
 
     Write-Host " - Upgrading all apps"
     Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -ErrorAction silentlycontinue

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -166,7 +166,7 @@ try {
     Write-Host "##[group]Download Artifacts"
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { ($_.target) -ne "bak" -and ($_.target) -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))) } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.target -ne "bak" -and $_.target -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))) } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder") } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -61,19 +61,6 @@ function Move-Database {
 
 }
 
-$blackListedApps = @(
-    [pscustomobject]@{
-        Name   = "CKL Monetization";
-        Id     = '2d648cd3-1779-449a-b0eb-23a98267d85e';
-        Reason = "works only on SaaS"
-    },
-    [pscustomobject]@{
-        Name   = "_Exclude_AnonymizedDataSharing_";
-        Id     = '063b3ac9-c464-4899-96e0-70d5425854e4';
-        Reason = "works only on SaaS"
-    }
-)
-
 if ($env:cosmoUpgradeSysApp) {
     Write-Host "System application upgrade requested"
     if (!$TenantId) { $TenantId = "default" }
@@ -321,6 +308,22 @@ if ($enablePerformanceCounter.ToLower() -eq "true") {
         Write-Host "Starting the $DCSName Data Collector Set"
         Start-SMPerformanceCollector -CollectorName $DCSName
     }
+}
+
+$blackListedApps = @(
+    [pscustomobject]@{
+        Name   = "CKL Monetization";
+        Id     = '2d648cd3-1779-449a-b0eb-23a98267d85e';
+        Reason = "works only on SaaS"
+    },
+    [pscustomobject]@{
+        Name   = "_Exclude_AnonymizedDataSharing_";
+        Id     = '063b3ac9-c464-4899-96e0-70d5425854e4';
+        Reason = "works only on SaaS"
+    }
+)
+if ($env:blackListedApps -and $env:blackListedApps.Count -gt 0) {
+    $blackListedApps += $env:blackListedApps
 }
 
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saasbakfile)) {

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -424,13 +424,13 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Upgrading tenant"
-    Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Stop -Tenant $TenantId
+    Start-NAVDataUpgrade -SkipUserSessionCheck -FunctionExecutionMode Serial -ServerInstance BC -SkipAppVersionCheck -Force -ErrorAction Continue -Tenant $TenantId
     Wait-DataUpgradeToFinish -ServerInstance BC -ErrorAction Stop -Tenant $TenantId
 
     Write-Host " - Check data upgrade is executed"
     Set-NavServerInstance -ServerInstance BC -Restart
     
-    for ($i = 0; $i -lt 20; $i++) {
+    for ($i = 0; $i -lt 10; $i++) {
         $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
         if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
             break;

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -412,10 +412,10 @@ if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrEmpty($env:saa
         -Force
 
     Write-Host " - Syncing all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Sync-NAVApp -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -Force -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Upgrading all apps"
-    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -ErrorAction silentlycontinue -WarningAction silentlycontinue
+    Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $tenantId | Start-NAVAppDataUpgrade -ServerInstance $ServerInstance -Tenant $tenantId -Name $_.Name -Publisher $_.Publisher -Version $_.Version -Force -ErrorAction silentlycontinue -WarningAction silentlycontinue
 
     Write-Host " - Syncing new tenant"
     Sync-NavTenant `

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -8,13 +8,13 @@ Write-Host "Start AdditionalSetup"
 if (!$TenantId) { $TenantId = "default" }
 $serverInstanceState = (Get-NAVServerInstance BC).State
 if ($serverInstanceState -ne "Running") {
-    Write-Host "Error: NAV ServerInstance not running, skipping AdditionalSetup..." -ForegroundColor Red
-    return
+    Write-Error "Error: NAV ServerInstance not running, aborting AdditionalSetup..."
+    exit 1
 }
 $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
 if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
-    Write-Host "Error: Tenant not mounted/operational, skipping AdditionalSetup..." -ForegroundColor Red
-    return
+    Write-Error "Error: Tenant not mounted/operational, aborting AdditionalSetup..."
+    exit 1
 }
 
 foreach ($script in $scripts) {

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -8,11 +8,13 @@ Write-Host "Start AdditionalSetup"
 if (!$TenantId) { $TenantId = "default" }
 $serverInstanceState = (Get-NAVServerInstance BC).State
 if ($serverInstanceState -ne "Running") {
-    throw "NAV ServerInstance not running, aborting AdditionalSetup"
+    Write-Error "NAV ServerInstance not running, skipping AdditionalSetup..."
+    return
 }
 $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
 if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
-    throw "Tenant not mounted/operational, aborting AdditionalSetup"
+    Write-Error "Tenant not mounted/operational, skipping AdditionalSetup..."
+    return
 }
 
 foreach ($script in $scripts) {

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -5,6 +5,18 @@ $scripts = @(
 
 Write-Host "Start AdditionalSetup"
 
+if (!$TenantId) { $TenantId = "default" }
+$serverInstanceState = (Get-NAVServerInstance BC).State
+if ($serverInstanceState -ne "Running") {
+    Write-Host "Error: NAV ServerInstance not running, aborting..." -ForegroundColor Red
+    return
+}
+$TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
+if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
+    Write-Host "Error: Tenant not mounted/operational, aborting..." -ForegroundColor Red
+    return
+}
+
 foreach ($script in $scripts) {
     if (Test-Path -Path $script) {
         Write-Host "Execute $script"

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -8,13 +8,11 @@ Write-Host "Start AdditionalSetup"
 if (!$TenantId) { $TenantId = "default" }
 $serverInstanceState = (Get-NAVServerInstance BC).State
 if ($serverInstanceState -ne "Running") {
-    Write-Error "Error: NAV ServerInstance not running, aborting AdditionalSetup..."
-    exit 1
+    throw "NAV ServerInstance not running, aborting AdditionalSetup"
 }
 $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
 if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
-    Write-Error "Error: Tenant not mounted/operational, aborting AdditionalSetup..."
-    exit 1
+    throw "Tenant not mounted/operational, aborting AdditionalSetup"
 }
 
 foreach ($script in $scripts) {

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -8,12 +8,12 @@ Write-Host "Start AdditionalSetup"
 if (!$TenantId) { $TenantId = "default" }
 $serverInstanceState = (Get-NAVServerInstance BC).State
 if ($serverInstanceState -ne "Running") {
-    Write-Host "Error: NAV ServerInstance not running, aborting..." -ForegroundColor Red
+    Write-Host "Error: NAV ServerInstance not running, skipping AdditionalSetup..." -ForegroundColor Red
     return
 }
 $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
 if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
-    Write-Host "Error: Tenant not mounted/operational, aborting..." -ForegroundColor Red
+    Write-Host "Error: Tenant not mounted/operational, skipping AdditionalSetup..." -ForegroundColor Red
     return
 }
 

--- a/base/my/navstart.ps1
+++ b/base/my/navstart.ps1
@@ -8,6 +8,18 @@ $scripts = @(
 Write-Host "Start"
 Write-Host "Running on Powershell Version:" $PSVersionTable.PSVersion
 
+if (!$TenantId) { $TenantId = "default" }
+$serverInstanceState = (Get-NAVServerInstance BC).State
+if ($serverInstanceState -ne "Running") {
+    Write-Host "Error: NAV ServerInstance not running, aborting..." -ForegroundColor Red
+    return
+}
+$TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
+if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
+    Write-Host "Error: Tenant not mounted/operational, aborting..." -ForegroundColor Red
+    return
+}
+
 foreach ($script in $scripts) {
     if (Test-Path -Path $script) {
         Write-Host "Execute $script"

--- a/base/my/navstart.ps1
+++ b/base/my/navstart.ps1
@@ -8,18 +8,6 @@ $scripts = @(
 Write-Host "Start"
 Write-Host "Running on Powershell Version:" $PSVersionTable.PSVersion
 
-if (!$TenantId) { $TenantId = "default" }
-$serverInstanceState = (Get-NAVServerInstance BC).State
-if ($serverInstanceState -ne "Running") {
-    Write-Host "Error: NAV ServerInstance not running, aborting..." -ForegroundColor Red
-    return
-}
-$TenantState = (Get-NavTenant -ServerInstance BC -Tenant $TenantId).State
-if ($TenantState -ne "Mounted" -and $TenantState -ne "Operational") {
-    Write-Host "Error: Tenant not mounted/operational, aborting..." -ForegroundColor Red
-    return
-}
-
 foreach ($script in $scripts) {
     if (Test-Path -Path $script) {
         Write-Host "Execute $script"


### PR DESCRIPTION
- rename blackListedApps to excludeAppsFromSaaSBak and make them extendable
- improve Wait-DataUpgradeToFinish to log errors correctly
- skip additional setup if NAV service is not running or tenant is not mounted
- improve synching and upgrading apps during backup restore
