### PR TITLE
Add pipeline for modified base app

### DIFF
--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -161,6 +161,7 @@ $env:nugetImported = $false
 
 $targetDir = "C:\run\my\apps"
 $targetDirManuallySorted = "C:\run\my\manuallysorted-apps"
+$targetDirAppsToPublishLater = "C:\run\my\apps-to-publish-later"
 $telemetryClient = Get-TelemetryClient -ErrorAction SilentlyContinue
 $properties = @{}
 
@@ -176,13 +177,15 @@ try {
     Write-Host "##[group]Download Artifacts"
     $started = Get-Date -Format "o"
     $artifacts = Get-ArtifactsFromEnvironment -path $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { "$($_.target)".ToLower() -ne "bak" -and "$($_.target)".ToLower() -ne "saasbak" -and ($_.name -eq $null -or ($_.name -ne $null -and !($_.name.StartsWith("sortorder")))) } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    $artifacts | Where-Object { $_.name -ne $null -and $_.name.StartsWith("sortorder") } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { "$($_.target)".ToLower() -notin @("bak", "saasbak") -and ($_.name -notmatch "^(sortorder|downloadonly)") } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.name -match "^sortorder" } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties
     $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct DE_*" })
     $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
+    
 }
 catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -197,8 +197,15 @@ try {
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties
-    $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct DE_*" })
+    $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct ??_*" })
     $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
+    if(![string]::IsNullOrEmpty($env:systemAppOnly)){
+        $companies = Get-NAVCompany -ServerInstance BC | Where-Object { $_.CompanyName -like "CRONUS*" }
+        foreach ($company in $companies) {
+            Write-Host "Remove company $($company.CompanyName)"
+            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC
+        }
+    }
     
 }
 catch {

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -180,11 +180,7 @@ try {
     $artifacts | Where-Object { "$($_.target)".ToLower() -notin @("bak", "saasbak") -and ($_.name -notmatch "^(sortorder|downloadonly)") } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^sortorder" } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
-    Start-Sleep (60*5)
-    $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater
-    Write-Host "Apps to publish later:"
-    $appsToPublishLater
-    Write-Host ""
+    $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater -ExcludeExpr "I_DONT_WANT_TO_EXCLUDE_ANYTHING" -ErrorAction SilentlyContinue
     [string[]] $appFullNames = $appsToPublishLater.Path
     $appFullNames | ForEach-Object { Write-Host "  $($_)" }
     Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appFullNames } | ForEach-Object { 

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -182,6 +182,7 @@ try {
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties
     $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct DE_*" })
+    $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
 }
 catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -237,7 +237,7 @@ if ((![string]::IsNullOrEmpty($env:saasbakfile) -or $installModifiedBaseAppManua
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Sync the system application"
-    Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Force
+    Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
     Write-Host "  Install the system application"
     Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -182,10 +182,17 @@ try {
     $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater -ExcludeExpr "I_DONT_WANT_TO_EXCLUDE_ANYTHING" -ErrorAction SilentlyContinue
     [string[]] $appFullNames = $appsToPublishLater.Path
+    Write-Host "##[group]Apps to publish later"
     $appFullNames | ForEach-Object { Write-Host "  $($_)" }
-    Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appFullNames } | ForEach-Object { 
-        Write-Host "  Removing $($_.FullName)"
-        Remove-Item -Path $_.FullName -Force 
+    Write-Host "##[endgroup]"
+    $appsToRemove = Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appFullNames }
+    if ($appsToRemove) {
+        Write-Host "##[group]Removing apps as they are older versions of apps that are already in the list to publish later"
+        $appsToRemove | ForEach-Object { 
+            Write-Host "  Removing $($_.FullName)"
+            Remove-Item -Path $_.FullName -Force 
+        }
+        Write-Host "##[endgroup]"
     }
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -198,15 +198,7 @@ try {
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties
     $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct ??_*" })
-    $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
-    if(![string]::IsNullOrEmpty($env:systemAppOnly)){
-        $companies = Get-NAVCompany -ServerInstance BC | Where-Object { $_.CompanyName -like "CRONUS*" }
-        foreach ($company in $companies) {
-            Write-Host "Remove company $($company.CompanyName)"
-            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC
-        }
-    }
-    
+    $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)    
 }
 catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error
@@ -218,6 +210,13 @@ finally {
 
 # Initialize company
 if ($env:mode -eq "4ps") {
+    if(![string]::IsNullOrEmpty($env:removeAllCompanies)){
+        $companies = Get-NAVCompany -ServerInstance BC | Where-Object { $_.CompanyName -like "CRONUS*" }
+        foreach ($company in $companies) {
+            Write-Host "Remove company $($company.CompanyName)"
+            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC
+        }
+    }
     $files = Get-DemoDataFiles
     foreach ($demoDataFile in $files) {
         $demoDataFileName = $demoDataFile | ForEach-Object { $_.Name }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -182,7 +182,10 @@ try {
     $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     Start-Sleep (60*5)
     $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater
-    [string[]] $appFullNames = $appsToPublishLater.FullName
+    Write-Host "Apps to publish later:"
+    $appsToPublishLater
+    Write-Host ""
+    [string[]] $appFullNames = $appsToPublishLater.Path
     $appFullNames | ForEach-Object { Write-Host "  $($_)" }
     Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appFullNames } | ForEach-Object { 
         Write-Host "  Removing $($_.FullName)"

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -180,6 +180,8 @@ try {
     $artifacts | Where-Object { "$($_.target)".ToLower() -notin @("bak", "saasbak") -and ($_.name -notmatch "^(sortorder|downloadonly)") } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^sortorder" } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater
+    Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appsToPublishLater.FullName } | ForEach-Object { Remove-Item -Path $_.FullName -Force }
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -231,7 +231,7 @@ if ((![string]::IsNullOrEmpty($env:saasbakfile) -or $installModifiedBaseAppManua
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Sync the system application"
-    Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+    Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Force
     Write-Host "  Install the system application"
     Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -180,8 +180,14 @@ try {
     $artifacts | Where-Object { "$($_.target)".ToLower() -notin @("bak", "saasbak") -and ($_.name -notmatch "^(sortorder|downloadonly)") } | Invoke-DownloadArtifact -destination $targetDir -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^sortorder" } | Invoke-DownloadArtifact -destination $targetDirManuallySorted -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
     $artifacts | Where-Object { $_.name -match "^downloadonly" } | Invoke-DownloadArtifact -destination $targetDirAppsToPublishLater -telemetryClient $telemetryClient -ErrorAction SilentlyContinue
+    Start-Sleep (60*5)
     $appsToPublishLater = Get-AppFilesSortedByDependencies -Path $targetDirAppsToPublishLater
-    Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appsToPublishLater.FullName } | ForEach-Object { Remove-Item -Path $_.FullName -Force }
+    [string[]] $appFullNames = $appsToPublishLater.FullName
+    $appFullNames | ForEach-Object { Write-Host "  $($_)" }
+    Get-ChildItem -Path $targetDirAppsToPublishLater -Recurse -Filter "*.app" | Where-Object { $_.FullName -notin $appFullNames } | ForEach-Object { 
+        Write-Host "  Removing $($_.FullName)"
+        Remove-Item -Path $_.FullName -Force 
+    }
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -69,8 +69,13 @@ function Get-AppFilesSortedByDependencies {
         foreach ($AppFile in $AllAppFiles) {
             try {
                 $App = Get-NAVAppInfo -Path $AppFile.FullName 
+                $AppId = $App.AppId
+                if ($App.Name -eq "Application") {
+                    $ApplicationAppId = $App.AppId
+                    $AppId = "00000000-0000-0000-0000-000000000000" 
+                }
                 if ($Distinct) {
-                    $equalApp = ($AllApps | Where-Object { $App.AppId -eq $_.AppId })
+                    $equalApp = ($AllApps | Where-Object { $AppId -eq $_.AppId })
                     if ($null -ne $equalApp) {
                         if ([System.Version]::Parse($App.Version) -gt [System.Version]::Parse($equalApp.Version)) {
                             $AllApps.Remove($equalApp)
@@ -79,11 +84,6 @@ function Get-AppFilesSortedByDependencies {
                             continue;
                         }
                     }
-                }
-                $AppId = $App.AppId
-                if ($App.Name -eq "Application") {
-                    $ApplicationAppId = $App.AppId
-                    $AppId = "00000000-0000-0000-0000-000000000000" 
                 }
                 $AllApps.Add([PSCustomObject]@{
                         AppId        = $AppId

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -64,18 +64,14 @@ function Get-AppFilesSortedByDependencies {
         $AllApps = [System.Collections.ArrayList]@()
         foreach ($AppFile in $AllAppFiles) {
             try {
-                Write-Host "Processing $($AppFile.FullName)"
                 $App = Get-NAVAppInfo -Path $AppFile.FullName 
                 if ($Distinct) {
                     $equalApp = ($AllApps | Where-Object { $App.AppId -eq $_.AppId })
                     if ($null -ne $equalApp) {
-                        Write-Host "Found equal app"
                         if ([System.Version]::Parse($App.Version) -gt [System.Version]::Parse($equalApp.Version)) {
-                            Write-Host "Removed version $($equalApp.Version) as $($App.Version) is greater."
                             $AllApps.Remove($equalApp)
                         }
                         else {
-                            Write-Host "Existing version $($equalApp.version) is greater than or equal to $($App.Version). Skipping this one."
                             continue;
                         }
                     }

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -60,9 +60,6 @@ function Get-AppFilesSortedByDependencies {
         }
         Write-Host ("Seraching for apps excluding: {0}" -f $ExcludeExpr)
         $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Recurse @optionalParameters | Where { $_.Name -NotMatch $ExcludeExpr }
-        Write-Host "AllAppFiles"
-        $AllAppFiles | ForEach-Object { Write-Host $_.FullName }
-        Write-Host ""
 
         $AllApps = [System.Collections.ArrayList]@()
         $ApplicationAppId = ""
@@ -99,9 +96,6 @@ function Get-AppFilesSortedByDependencies {
                 Write-Warning "Got no AppInfo from $AppFile ... $_"
             }
         }
-        Write-Host "AllApps"
-        $AllApps | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
-        Write-Host ""
         $FinalResult = @()
 
         $AllApps | ForEach-Object {    
@@ -109,13 +103,7 @@ function Get-AppFilesSortedByDependencies {
         }
 
         $FinalResult = $FinalResult | Sort-Object ProcessOrder
-        Write-Host "Before"
-        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
-        Write-Host ""
-        Write-Host "Now changing the Application AppId to $ApplicationAppId"
         $FinalResult | Where-Object { $_.Name -eq "Application" } | Foreach-Object { $_.AppId = $ApplicationAppId }
-        Write-Host "After"
-        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
         return $FinalResult
     }
 }

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -104,8 +104,12 @@ function Get-AppFilesSortedByDependencies {
         }
 
         $FinalResult = $FinalResult | Sort-Object ProcessOrder
+        Write-Host "Before"
+        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host}
+        Write-Host "Now changing the Application AppId to $ApplicationAppId"
         $FinalResult | Where-Object { $_.Name -eq "Application" } | Foreach-Object { $_.AppId = $ApplicationAppId }
-
+        Write-Host "After"
+        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host}
         return $FinalResult
     }
 }

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -60,6 +60,9 @@ function Get-AppFilesSortedByDependencies {
         }
         Write-Host ("Seraching for apps excluding: {0}" -f $ExcludeExpr)
         $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Recurse @optionalParameters | Where { $_.Name -NotMatch $ExcludeExpr }
+        Write-Host "AllAppFiles"
+        $AllAppFiles | ForEach-Object { Write-Host $_.FullName }
+        Write-Host ""
 
         $AllApps = [System.Collections.ArrayList]@()
         $ApplicationAppId = ""
@@ -96,7 +99,9 @@ function Get-AppFilesSortedByDependencies {
                 Write-Warning "Got no AppInfo from $AppFile ... $_"
             }
         }
-        
+        Write-Host "AllApps"
+        $AllApps | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
+        Write-Host ""
         $FinalResult = @()
 
         $AllApps | ForEach-Object {    
@@ -105,11 +110,12 @@ function Get-AppFilesSortedByDependencies {
 
         $FinalResult = $FinalResult | Sort-Object ProcessOrder
         Write-Host "Before"
-        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host}
+        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
+        Write-Host ""
         Write-Host "Now changing the Application AppId to $ApplicationAppId"
         $FinalResult | Where-Object { $_.Name -eq "Application" } | Foreach-Object { $_.AppId = $ApplicationAppId }
         Write-Host "After"
-        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host}
+        $FinalResult | ForEach-Object { ConvertTo-Json $_ -Compress -Depth 100 | Write-Host; Write-Host ""}
         return $FinalResult
     }
 }

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -62,6 +62,7 @@ function Get-AppFilesSortedByDependencies {
         $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Recurse @optionalParameters | Where { $_.Name -NotMatch $ExcludeExpr }
 
         $AllApps = [System.Collections.ArrayList]@()
+        $ApplicationAppId = ""
         foreach ($AppFile in $AllAppFiles) {
             try {
                 $App = Get-NAVAppInfo -Path $AppFile.FullName 
@@ -76,8 +77,13 @@ function Get-AppFilesSortedByDependencies {
                         }
                     }
                 }
+                $AppId = $App.AppId
+                if ($App.Name -eq "Application") {
+                    $ApplicationAppId = $App.AppId
+                    $AppId = "00000000-0000-0000-0000-000000000000" 
+                }
                 $AllApps.Add([PSCustomObject]@{
-                        AppId        = $App.AppId
+                        AppId        = $AppId
                         Version      = $App.Version
                         Name         = $App.Name
                         Publisher    = $App.Publisher
@@ -98,6 +104,7 @@ function Get-AppFilesSortedByDependencies {
         }
 
         $FinalResult = $FinalResult | Sort-Object ProcessOrder
+        $FinalResult | Where-Object { $_.Name -eq "Application" } | Foreach-Object { $_.AppId = $ApplicationAppId }
 
         return $FinalResult
     }

--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -23,7 +23,9 @@ function Import-Artifacts {
         [Parameter(Mandatory = $false)]
         [System.Object]$telemetryClient = $null,
         [Parameter(Mandatory = $false)]
-        [bool]$SkipFontImport = $false
+        [bool]$SkipFontImport = $false,
+        [Parameter(Mandatory = $false)]
+        [bool]$throwErrors = $false
     )
     
     begin {
@@ -55,6 +57,9 @@ function Import-Artifacts {
             }
             catch {
                 Write-Host "Import FOBs Error: $($_.Exception.Message)" -f Red  | Out-String
+                if($throwErrors) {
+                    throw $_
+                }
             }
             finally {
                 Write-Host "Import FOBs done. (Duration: $(New-TimeSpan -start $started -end (Get-Date)))"
@@ -107,6 +112,9 @@ function Import-Artifacts {
             }
             catch {
                 Write-Host "Import Apps Error: $($_.Exception.Message)" -f Red
+                if($throwErrors) {
+                    throw $_
+                }
             }
             finally {
                 Write-Host "Import Apps done. (Duration: $(New-TimeSpan -start $started -end (Get-Date)))"
@@ -134,6 +142,9 @@ function Import-Artifacts {
             }
             catch {
                 Write-Host "Import RapidStart packages Error: $($_.Exception.Message)" -f Red
+                if($throwErrors) {
+                    throw $_
+                }
             }
             finally {
                 Write-Host "Import RapidStart packages done. (Duration: $(New-TimeSpan -start $started -end (Get-Date)))"
@@ -160,6 +171,9 @@ function Import-Artifacts {
             }
             catch {
                 Write-Host "Import Fonts Error: $($_.Exception.Message)" -f Red  | Out-String
+                if($throwErrors) {
+                    throw $_
+                }
             }
             finally {
                 Write-Host "Import Fonts done. (Duration: $(New-TimeSpan -start $started -end (Get-Date)))"


### PR DESCRIPTION
- "downloadonly_" prefixes saves files in different directory, so that they can already be downloaded, but published later
- systemAppOnly environment variable removes also all apps first, so that modified base app can be published afterwards
- removeAllCompanies environment variable removes all companies
- Improve `Get-AppFilesSortedByDependencies` so that Application-App is sorted correctly
- Add `throwErrors` parameter to `Import-Artifacts` function