### PR TITLE
feat(output): add version of the BC server executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Download artifacts grouped by dependency and import only independent
 - Add pwsh as ssh default shell for BC24+
 - Find path of pwsh.exe with where.exe
+- Add version of bc server executable to output at startup

--- a/base/AdditionalOutput.ps1
+++ b/base/AdditionalOutput.ps1
@@ -1,0 +1,3 @@
+# Output version of the business central server executable
+$bcVersion = [Version](Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Server.exe").VersionInfo.FileVersion
+Write-Host "Dev. Server Version : $bcVersion"


### PR DESCRIPTION
Add the file version of the business central server executable to the output.
This enables the possiblity to read the version in the azure devops build pipeline from the log (like the ip and serverinstance name).