### PR TITLE
feat(setup): increase SQL timeout for database backup restore

### DIFF
--- a/base/my/SetupVariables.ps1
+++ b/base/my/SetupVariables.ps1
@@ -1,6 +1,6 @@
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrWhiteSpace($env:bakfile)) {
     Write-Host "Increasing SQL timeout to 600 seconds for database backup restore"
-    $env:SqlTimeout = "2"
+    $env:SqlTimeout = "600"
 }
 
 # invoke default

--- a/base/my/SetupVariables.ps1
+++ b/base/my/SetupVariables.ps1
@@ -1,6 +1,6 @@
 if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrWhiteSpace($env:bakfile)) {
     Write-Host "Increasing SQL timeout to 600 seconds for database backup restore"
-    $env:SqlTimeout = "600"
+    $env:SqlTimeout = "2"
 }
 
 # invoke default

--- a/base/my/SetupVariables.ps1
+++ b/base/my/SetupVariables.ps1
@@ -1,0 +1,7 @@
+if (($env:cosmoServiceRestart -eq $false) -and ![string]::IsNullOrWhiteSpace($env:bakfile)) {
+    Write-Host "Increasing SQL timeout to 600 seconds for database backup restore"
+    $env:SqlTimeout = "600"
+}
+
+# invoke default
+. (Join-Path $runPath $MyInvocation.MyCommand.Name)


### PR DESCRIPTION
[Creating the NAV database from a backup file](https://github.com/microsoft/nav-docker/blob/5a2606eda6ae0e339e08453936414824df1c877c/generic/Run/SetupDatabase.ps1#L75C25-L75C45) may not complete within the [default timeout of 300 seconds](https://github.com/microsoft/nav-docker/blob/5a2606eda6ae0e339e08453936414824df1c877c/generic/Run/SetupVariables.ps1#L154-L157)