### PR TITLE
Synchronize 4PS changes

### DIFF
--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -101,8 +101,8 @@ function Invoke-4PSArtifactHandling {
                         Invoke-NavCodeunit `
                             -ServerInstance BC `
                             -CompanyName $companyName `
-                            -CodeunitId 11012268 `
-                            -MethodName ImportSetupDataFromXmlFile `
+                            -CodeunitId 11012251 `
+                            -MethodName ImportDemoData `
                             -Argument "$($demoDataFile.FullName)"
                         
                         if ($use4PSContainerInitializer) {
@@ -158,7 +158,7 @@ function Invoke-4PSArtifactHandling {
                                 Invoke-NavCodeunit `
                                     -ServerInstance BC `
                                     -CompanyName $companyName `
-                                    -CodeunitId 11128546 `
+                                    -CodeunitId 50189 `
                                     -MethodName InitializeOSA
 
                                 Write-Host "    Initialize License"

--- a/artifacts/4PS/Set-AlpacaContainerKeyVaultAadAppAndCertificate.ps1
+++ b/artifacts/4PS/Set-AlpacaContainerKeyVaultAadAppAndCertificate.ps1
@@ -1,0 +1,49 @@
+# https://github.com/microsoft/navcontainerhelper/blob/main/ContainerHandling/Set-BcContainerKeyVaultAadAppAndCertificate.ps1
+
+if ($env:mode -ne "4ps") {
+    Write-Host "This script is only supported in 4PS mode"
+    return
+}
+Write-Host "Add client certificate for KeyVault access to Service Tier."
+# Params
+$serverInstance = "BC";
+$enablePublisherValidation = $false;
+$pfxFile = "C:/azurefileshare/common/AlpacaContainerKeyVaultReader.pfx";
+$pfxPassword = (ConvertTo-SecureString -String "P@ssw0rd" -AsPlainText -Force);
+$clientId = "6efd7c53-94d3-489e-95a4-30e25de612ba";
+$doNotRestartServiceTier = $true;
+
+Set-NAVServerConfiguration -ServerInstance $serverInstance -KeyName "AzureKeyVaultAppSecretsPublisherValidationEnabled" -KeyValue $enablePublisherValidation.ToString().ToLowerInvariant() -WarningAction SilentlyContinue
+        
+$importedPfxCertificate = Import-PfxCertificate -FilePath $pfxFile -Password $pfxPassword -CertStoreLocation Cert:\LocalMachine\My
+Write-Host "Keyvault Certificate Thumbprint: $($importedPfxCertificate.Thumbprint)"
+
+# Give SYSTEM permission to use the PFX file's private key
+$keyName = $importedPfxCertificate.PrivateKey.Key.UniqueName
+$keyPath = "C:\ProgramData\Microsoft\Crypto\RSA\MachineKeys\$keyName"
+if ($PSVersionTable.PSVersion -ge "6.0.0") {
+    Import-Module Microsoft.PowerShell.Security -Force
+    $acl = [System.IO.FileSystemAclExtensions]::GetAccessControl([System.IO.DirectoryInfo]::new($keyPath), 'Access')
+}
+else {
+    $acl = (Get-Item $keyPath).GetAccessControl('Access')
+}
+$permission = 'NT AUTHORITY\SYSTEM',"Full","Allow"
+$accessRule = new-object System.Security.AccessControl.FileSystemAccessRule $permission
+$acl.AddAccessRule($accessRule)
+Set-Acl $keyPath $acl
+#$acl.Access
+
+Set-NavServerConfiguration -ServerInstance $serverInstance -KeyName AzureKeyVaultClientCertificateStoreLocation -KeyValue "LocalMachine" -WarningAction SilentlyContinue
+Set-NavServerConfiguration -ServerInstance $serverInstance -KeyName AzureKeyVaultClientCertificateStoreName     -KeyValue "My" -WarningAction SilentlyContinue
+Set-NavServerConfiguration -ServerInstance $serverInstance -KeyName AzureKeyVaultClientCertificateThumbprint    -KeyValue $importedPfxCertificate.Thumbprint -WarningAction SilentlyContinue
+Set-NavServerConfiguration -ServerInstance $serverInstance -KeyName AzureKeyVaultClientId                       -KeyValue $clientId -WarningAction SilentlyContinue
+
+if (!$doNotRestartServiceTier) {
+    Write-Host "Restarting Service Tier"
+    Set-NAVServerInstance -ServerInstance $serverInstance -Restart
+    while (Get-NavTenant $serverInstance | Where-Object { $_.State -eq "Mounting" }) {
+        Start-Sleep -Seconds 1
+    }
+}
+Write-Host "Client certificate for KeyVault access imported."

--- a/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
+++ b/artifacts/4PS/Unpublish-AllNavAppsInServerInstance.ps1
@@ -16,7 +16,8 @@ function Unpublish-AllNavAppsInServerInstance {
     PARAM
     (
         [string]$ServerInstance,
-        [string]$Tenant
+        [string]$Tenant,
+        [bool]$KeepData
     )
     PROCESS {
         if (!$Tenant) {
@@ -31,7 +32,12 @@ function Unpublish-AllNavAppsInServerInstance {
         $InstalledApps = Get-NAVAppInfo -ServerInstance $ServerInstance -TenantSpecificProperties -Tenant $Tenant | where-object 'IsInstalled' -eq $true 
         
         foreach ($InstalledApp in $InstalledApps) {
-            uninstall-navapp -Name $InstalledApp.name -Version $InstalledApp.Version -ServerInstance $ServerInstance -Force -WarningAction SilentlyContinue
+            if($KeepData) {
+                Uninstall-NAVApp -Name $InstalledApp.name -Version $InstalledApp.Version -ServerInstance $ServerInstance -Force -WarningAction SilentlyContinue
+            }
+            else {
+                Uninstall-NAVApp -Name $InstalledApp.name -Version $InstalledApp.Version -ServerInstance $ServerInstance -Force -DoNotSaveData -WarningAction SilentlyContinue
+            }
         }
         
         while (Get-NAVAppInfo -ServerInstance $ServerInstance) {
@@ -39,8 +45,8 @@ function Unpublish-AllNavAppsInServerInstance {
             $ExistingApps = Get-NAVAppInfo -ServerInstance $ServerInstance -TenantSpecificProperties -Tenant $Tenant 
         
             foreach ($ExistingApp in $ExistingApps) {  
-                unpublish-navapp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
-                if (!(get-navappinfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
+                Unpublish-NAVApp -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance -ErrorAction SilentlyContinue
+                if (!(Get-NAVAppInfo -Name $ExistingApp.name -Version $ExistingApp.Version -ServerInstance $ServerInstance)) {
                     "App {0} with version {1} unpublished..." -f $ExistingApp.name, $ExistingApp.Version
                 }
             }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -206,10 +206,10 @@ finally {
 # Initialize company
 if ($env:mode -eq "4ps") {
     if(![string]::IsNullOrEmpty($env:removeAllCompanies)){
-        $companies = Get-NAVCompany -ServerInstance BC | Where-Object { $_.CompanyName -like "CRONUS*" }
+        $companies = Get-NAVCompany -ServerInstance BC -Tenant $TenantId | Where-Object { $_.CompanyName -like "CRONUS*" }
         foreach ($company in $companies) {
             Write-Host "Remove company $($company.CompanyName)"
-            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC -Force
+            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC -Force -Tenant $TenantId
             Write-Host "Company $($company.CompanyName) removed."
         }
     }
@@ -220,7 +220,7 @@ if ($env:mode -eq "4ps") {
         if ($demoDataFileName -match 'DemoData_(.*)_.xml') {
             $companyName = $Matches[1]
             Write-Host "  Create company $companyName"
-            New-NAVCompany -CompanyName $companyName -ServerInstance BC
+            New-NAVCompany -CompanyName $companyName -ServerInstance BC -Tenant $TenantId
         }
     }
 }

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -228,7 +228,7 @@ if ($env:mode -eq "4ps") {
 # If SaaS backup for 4PS (modified base app), we need to remove all apps and reinstall the System App first
 if ((![string]::IsNullOrEmpty($env:saasbakfile) -or $installModifiedBaseAppManually) -and $env:mode -eq "4ps" -and $env:cosmoServiceRestart -eq $false) {
     Write-Host "Identified SaaS Backup and 4PS mode, removing all apps to cleanly rebuild later"
-    Unpublish-AllNavAppsInServerInstance
+    Unpublish-AllNavAppsInServerInstance -KeepData (![string]::IsNullOrEmpty($env:saasbakfile))
     $sysAppInfoFS = Get-NAVAppInfo -Path 'C:\Applications\system application\source\Microsoft_System Application.app'
     Write-Host "  Publish the system application $($sysAppInfoFS.Version)"
     Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\system application\source\Microsoft_System Application.app'

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -192,7 +192,8 @@ try {
  
     $properties["artifacts"] = ($artifacts | ConvertTo-Json -Depth 50 -ErrorAction SilentlyContinue)
     Invoke-LogOperation -name "AdditionalSetup - Get Artifacts" -started $started -telemetryClient $telemetryClient -properties $properties
-    $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct DE_*" })
+    $installModifiedBaseAppManually = $null -ne ($artifacts | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct ??_*" })
+    $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)    
 }
 catch {
     Add-ArtifactsLog -message "Download Artifacts Error: $($_.Exception.Message)" -severity Error
@@ -204,6 +205,14 @@ finally {
 
 # Initialize company
 if ($env:mode -eq "4ps") {
+    if(![string]::IsNullOrEmpty($env:removeAllCompanies)){
+        $companies = Get-NAVCompany -ServerInstance BC | Where-Object { $_.CompanyName -like "CRONUS*" }
+        foreach ($company in $companies) {
+            Write-Host "Remove company $($company.CompanyName)"
+            Remove-NAVCompany -CompanyName $company.CompanyName -ServerInstance BC -Force
+            Write-Host "Company $($company.CompanyName) removed."
+        }
+    }
     $files = Get-DemoDataFiles
     foreach ($demoDataFile in $files) {
         $demoDataFileName = $demoDataFile | ForEach-Object { $_.Name }

--- a/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
+++ b/artifacts/ArtifactHandling/Get-AppFilesSortedByDependencies.ps1
@@ -62,26 +62,28 @@ function Get-AppFilesSortedByDependencies {
         $AllAppFiles = Get-ChildItem -LiteralPath "$Path" -Filter $Filter -Recurse @optionalParameters | Where { $_.Name -NotMatch $ExcludeExpr }
 
         $AllApps = [System.Collections.ArrayList]@()
+        $ApplicationAppId = ""
         foreach ($AppFile in $AllAppFiles) {
             try {
-                Write-Host "Processing $($AppFile.FullName)"
                 $App = Get-NAVAppInfo -Path $AppFile.FullName 
+                $AppId = $App.AppId
+                if ($App.Name -eq "Application") {
+                    $ApplicationAppId = $App.AppId
+                    $AppId = "00000000-0000-0000-0000-000000000000" 
+                }
                 if ($Distinct) {
-                    $equalApp = ($AllApps | Where-Object { $App.AppId -eq $_.AppId })
+                    $equalApp = ($AllApps | Where-Object { $AppId -eq $_.AppId })
                     if ($null -ne $equalApp) {
-                        Write-Host "Found equal app"
                         if ([System.Version]::Parse($App.Version) -gt [System.Version]::Parse($equalApp.Version)) {
-                            Write-Host "Removed version $($equalApp.Version) as $($App.Version) is greater."
                             $AllApps.Remove($equalApp)
                         }
                         else {
-                            Write-Host "Existing version $($equalApp.version) is greater than or equal to $($App.Version). Skipping this one."
                             continue;
                         }
                     }
                 }
                 $AllApps.Add([PSCustomObject]@{
-                        AppId        = $App.AppId
+                        AppId        = $AppId
                         Version      = $App.Version
                         Name         = $App.Name
                         Publisher    = $App.Publisher
@@ -94,7 +96,6 @@ function Get-AppFilesSortedByDependencies {
                 Write-Warning "Got no AppInfo from $AppFile ... $_"
             }
         }
-        
         $FinalResult = @()
 
         $AllApps | ForEach-Object {    
@@ -102,7 +103,7 @@ function Get-AppFilesSortedByDependencies {
         }
 
         $FinalResult = $FinalResult | Sort-Object ProcessOrder
-
+        $FinalResult | Where-Object { $_.Name -eq "Application" } | Foreach-Object { $_.AppId = $ApplicationAppId }
         return $FinalResult
     }
 }

--- a/artifacts/ArtifactHandling/Import-AppArtifact.ps1
+++ b/artifacts/ArtifactHandling/Import-AppArtifact.ps1
@@ -63,6 +63,7 @@ function Import-AppArtifact {
             
             # Uninstall old NAVApp, when present
             if ($oldApp -and $oldApp.IsInstalled) {
+                $sameVersionAlreadyPublished = $false
                 try {
                     if ($oldApp.Version -ge $app.Version) {
                         Write-Host "Skipping installation of App $($app.Name) $($app.Publisher) $($app.Version) as version $($oldApp.Version) is already installed."
@@ -88,7 +89,8 @@ function Import-AppArtifact {
                 }
             }
             else {
-                if ($oldApp) {
+                $sameVersionAlreadyPublished = $oldApp -and $oldApp.IsPublished -and ($oldApp.Version -eq $app.Version)
+                if ($oldApp -and !$sameVersionAlreadyPublished) {
                     $runDataUpgrade = $true
                 }
                 else {
@@ -99,36 +101,41 @@ function Import-AppArtifact {
     
             # Publish NAVApp
             if ($success) {
-                try {
-                    $started2 = Get-Date -Format "o"
-                    Add-ArtifactsLog -kind App -message "Publish App $($app.Name) $($app.Publisher) $($app.Version) Scope: $Scope ..." -data $app
-
-                    $optionalParameters = @{ }
-                    # Special handling for NAV2018
-                    # '-Force' is only added, when 'SandboxDatabaseName' (NAV2018) is NOT present because parameter '-Force' works only when 'SandboxDatabaseName' is not empty
-                    if (! ((Get-Command Publish-NAVApp).Parameters.SandboxDatabaseName)) {
-                        $optionalParameters["Force"] = $true
-                    }
-                    if ((Get-Command Publish-NAVApp).Parameters.Scope) {
-                        $optionalParameters["Scope"] = "$Scope"
-                    }
-                    if (("$Scope" -eq "Tenant") -and ((Get-Command Publish-NAVApp).Parameters.Tenant)) {
-                        $optionalParameters["Tenant"] = $Tenant
-                    }
-
-                    Publish-NavApp -ServerInstance $ServerInstance -Path $Path @optionalParameters -SkipVerification -ErrorAction SilentlyContinue -ErrorVariable err -WarningVariable warn -InformationVariable info
-                    $info | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Info  -data $app }
-                    $warn | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Warn  -data $app }
-                    $err  | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Error -data $app }
-                    $success = ! $err
-                    if ($success) { Add-ArtifactsLog -kind App -message "Publish App successful" -data $app -success success }
+                if ($sameVersionAlreadyPublished) {
+                    Write-Host "Skipping publishing of App $($app.Name) $($app.Publisher) $($app.Version) as version $($oldApp.Version) is already published."
                 }
-                catch {
-                    Add-ArtifactsLog -kind App -message "Publish App $($app.Name) $($app.Publisher) $($app.Version) FAILED:$([System.Environment]::NewLine)  $($_.Exception.Message)" -data $app -success fail -severity Error
-                    $success = $false
-                }
-                finally {
-                    Invoke-LogOperation -name "Publish App" -started $started2 -properties $properties -success $success -telemetryClient $telemetryClient
+                else {
+                    try {
+                        $started2 = Get-Date -Format "o"
+                        Add-ArtifactsLog -kind App -message "Publish App $($app.Name) $($app.Publisher) $($app.Version) Scope: $Scope ..." -data $app
+    
+                        $optionalParameters = @{ }
+                        # Special handling for NAV2018
+                        # '-Force' is only added, when 'SandboxDatabaseName' (NAV2018) is NOT present because parameter '-Force' works only when 'SandboxDatabaseName' is not empty
+                        if (! ((Get-Command Publish-NAVApp).Parameters.SandboxDatabaseName)) {
+                            $optionalParameters["Force"] = $true
+                        }
+                        if ((Get-Command Publish-NAVApp).Parameters.Scope) {
+                            $optionalParameters["Scope"] = "$Scope"
+                        }
+                        if (("$Scope" -eq "Tenant") -and ((Get-Command Publish-NAVApp).Parameters.Tenant)) {
+                            $optionalParameters["Tenant"] = $Tenant
+                        }
+
+                        Publish-NavApp -ServerInstance $ServerInstance -Path $Path @optionalParameters -SkipVerification -ErrorAction SilentlyContinue -ErrorVariable err -WarningVariable warn -InformationVariable info
+                        $info | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Info  -data $app }
+                        $warn | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Warn  -data $app }
+                        $err  | foreach { Add-ArtifactsLog -kind App -message "$_" -severity Error -data $app }
+                        $success = ! $err
+                        if ($success) { Add-ArtifactsLog -kind App -message "Publish App successful" -data $app -success success }
+                    }
+                    catch {
+                        Add-ArtifactsLog -kind App -message "Publish App $($app.Name) $($app.Publisher) $($app.Version) FAILED:$([System.Environment]::NewLine)  $($_.Exception.Message)" -data $app -success fail -severity Error
+                        $success = $false
+                    }
+                    finally {
+                        Invoke-LogOperation -name "Publish App" -started $started2 -properties $properties -success $success -telemetryClient $telemetryClient
+                    }
                 }
                 $skipInstall = ! $success
             }

--- a/base/my/SetupConfiguration.ps1
+++ b/base/my/SetupConfiguration.ps1
@@ -2,6 +2,7 @@ Write-Host "Start Setup Configuration"
 
 $scripts = @(
                         (Join-Path $runPath "EnablePerformanceCounter.ps1")
+                        (Join-Path $runPath "4PS/Set-AlpacaContainerKeyVaultAadAppAndCertificate.ps1")
 )
 Push-Location
 # invoke default

--- a/custom-scripts/my/CC-DownloadCustomScripts.ps1
+++ b/custom-scripts/my/CC-DownloadCustomScripts.ps1
@@ -17,8 +17,15 @@ $Headers = @{
 $url = "https://dev.azure.com/$($env:CcOrgName)/$($env:CcProjectId)/_apis/git/repositories/$($env:CcRepoId)/items?path=%2F.container-my&download=true&resolveLfs=true&%24format=zip&api-version=5.0"
 
 if (-not [string]::IsNullOrEmpty($env:CcBranch)) {
-    $url += "&versionDescriptor%5Bversion%5D=$([System.Uri]::EscapeDataString($env:CcBranch))"
-    Write-Host "- Using branch $($env:CcBranch)"
+    $commitHashPattern = "^[0-9a-f]{40}$"
+    if ($env:CcBranch -match $commitHashPattern) {
+        $url += "&versionDescriptor.versionType=commit&versionDescriptor.version=$($env:CcBranch)"
+        Write-Host "- Using commit hash $($env:CcBranch)"
+    }
+    else {
+        $url += "&versionDescriptor%5Bversion%5D=$([System.Uri]::EscapeDataString($env:CcBranch))"
+        Write-Host "- Using branch $($env:CcBranch)"
+    }
 }
 elseif (([string]::IsNullOrEmpty($env:CcBranch)) -and (-not [string]::IsNullOrEmpty($env:AZP_CONFIG_REPO_PATH))) {
     $url += "&versionDescriptor%5Bversion%5D=master"


### PR DESCRIPTION
- Updated Invoke-NavCodeunit for Import Demo Data
- Add script to service tier startup that imports client certificate to container, so that the container can access the key vaults
- Fix sorting of apps when Application app is an artifact to be published
- Add systemAppOnly and removeAllCompanies environment variables, so that they can be used in custom scripts
- Download custom scripts works now also with commits (necessary in Pull Requests as there the merged custom scripts from source and target branch should be used)
- Improve Import-AppArtifact when restoring a bak/saasbak as then it might be that some apps are already published, but not installed.
- Unpublish-AllNavAppsInServerInstance supports now the DoNotSaveData switch