### PR TITLE
Execute 4PS initialization if the modified base app was downloaded and published

### DIFF
--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -16,9 +16,9 @@ function Invoke-4PSArtifactHandling {
 
             $appDatabaseName = Get-AppDatabaseName
             Write-Host "  app database name is: $appDatabaseName"
-            $isMsftStandardDatabase = [string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
+            $isModifiedBaseAppInstalled = ![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
             $isSaaSBak = ![string]::IsNullOrEmpty($env:saasbakfile)
-            if(!$isMsftStandardDatabase -and !$isSaaSBak) {
+            if($isModifiedBaseAppInstalled -and !$isSaaSBak) {
                 Write-Host "  modified base app was installed, therefore this is not a microsoft standard database"
             }
 
@@ -28,7 +28,7 @@ function Invoke-4PSArtifactHandling {
             elseif($isSaaSBak) {
                 Write-Host "4PS initialization skipped as this seems to be a SaaS backup restore"
             }
-            elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and $isMsftStandardDatabase) {
+            elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and !$isModifiedBaseAppInstalled) {
                 Write-Host "4PS initialization skipped as this seems to be a Microsoft standard database"
             }
             else {

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -16,15 +16,19 @@ function Invoke-4PSArtifactHandling {
 
             $appDatabaseName = Get-AppDatabaseName
             Write-Host "  app database name is: $appDatabaseName"
-            $msftStandardDatabase = [string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
-            if(!$msftStandardDatabase) {
+            $isMsftStandardDatabase = [string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
+            $isSaaSBak = ![string]::IsNullOrEmpty($env:saasbakfile)
+            if(!$isMsftStandardDatabase -and !$isSaaSBak) {
                 Write-Host "  modified base app was installed, therefore this is not a microsoft standard database"
             }
 
             if ($env:cosmoServiceRestart -eq $true) {
                 Write-Host "4PS initialization skipped as this seems to be a service restart"
             }
-            elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and $msftStandardDatabase) {
+            elseif($isSaaSBak) {
+                Write-Host "4PS initialization skipped as this seems to be a SaaS backup restore"
+            }
+            elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and $isMsftStandardDatabase) {
                 Write-Host "4PS initialization skipped as this seems to be a Microsoft standard database"
             }
             else {

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -16,11 +16,15 @@ function Invoke-4PSArtifactHandling {
 
             $appDatabaseName = Get-AppDatabaseName
             Write-Host "  app database name is: $appDatabaseName"
+            $msftStandardDatabase = [string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
+            if(!$msftStandardDatabase) {
+                Write-Host "  modified base app was installed, therefore this is not a microsoft standard database"
+            }
 
             if ($env:cosmoServiceRestart -eq $true) {
                 Write-Host "4PS initialization skipped as this seems to be a service restart"
             }
-            elseif ("CRONUS" -eq $appDatabaseName -or "default" -eq $appDatabaseName) {
+            elseif ("CRONUS" -eq $appDatabaseName -or "default" -eq $appDatabaseName -and !$msftStandardDatabase) {
                 Write-Host "4PS initialization skipped as this seems to be a Microsoft standard database"
             }
             else {

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -24,7 +24,7 @@ function Invoke-4PSArtifactHandling {
             if ($env:cosmoServiceRestart -eq $true) {
                 Write-Host "4PS initialization skipped as this seems to be a service restart"
             }
-            elseif ("CRONUS" -eq $appDatabaseName -or "default" -eq $appDatabaseName -and !$msftStandardDatabase) {
+            elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and $msftStandardDatabase) {
                 Write-Host "4PS initialization skipped as this seems to be a Microsoft standard database"
             }
             else {


### PR DESCRIPTION
Initialization is working again if we also check the `$env:cosmoBaseAppVersion`
![image](https://github.com/user-attachments/assets/ef39e353-a97a-45f4-ae3c-99e0c05cada6)


Wenn eine .bak genutzt wurde, ist die appDatabaseName = myDatabase, weshalb es geklappt hatte, wenn man eine .bak verwendet:
![image](https://github.com/user-attachments/assets/00b1a73c-b1b0-4229-b510-c00d710e99b6)
![image](https://github.com/user-attachments/assets/0ea1a294-d7fd-4e74-a5ff-1dcd17262799)


