### PR TITLE
fix(artifacts): use micorosft nuget feeds for apps and not for symbols

### DIFF
--- a/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
@@ -11,9 +11,7 @@
     process {
         Write-Host "Collecting Microsoft NuGet feeds"
         @( 
-            "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSSymbols/nuget/v3/index.json",
-            "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSSymbols/nuget/v3/index.json",
-            "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/AppSourceSymbols/nuget/v3/index.json"
+            "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSApps/nuget/v3/index.json"
         ) | 
             ForEach-Object {
                 Write-Host "Adding NuGet feed: $_"


### PR DESCRIPTION
[AB#4326](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4326)