### PR TITLE
feat(owners): Additional owners are also set up as users

### DIFF
--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -180,7 +180,7 @@ $installModifiedBaseAppManually = $null -ne ( $global:cosmoArtifacts.Artifacts.A
 $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
 
 # Initialize company
-if ($env:mode -eq "4ps") {
+if ($env:mode -eq "4ps" -and $env:cosmoServiceRestart -eq $false) {
     if(![string]::IsNullOrEmpty($env:removeAllCompanies)){
         $companies = Get-NAVCompany -ServerInstance BC -Tenant $TenantId | Where-Object { $_.CompanyName -like "CRONUS*" }
         foreach ($company in $companies) {

--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -1,7 +1,8 @@
 $scripts = @(
                         (Join-Path $PSScriptRoot "AdditionalSetupArtifacts.ps1"),
                         (Join-Path $PSScriptRoot "AdditionalSetupPrerequisites.ps1"),
-                        (Join-Path $PSScriptRoot "AdditionalSetupDuplicateUsers.ps1")
+                        (Join-Path $PSScriptRoot "AdditionalSetupDuplicateUsers.ps1"),
+                        (Join-Path $PSScriptRoot "AdditionalSetupAdditionalOwners.ps1")
 )
 
 Write-Host "Start AdditionalSetup"

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -10,6 +10,8 @@ if ($env:auth -ieq "aad") {
     $navuserpasswordAuth = $false
 }
 
+$PermissionSet  = 'SUPER'
+
 $accounts = @($env:owner.Split(","))
 
 foreach ($account in $accounts) {

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -15,7 +15,10 @@ $accounts = @($env:owner.Split(","))
 foreach ($account in $accounts) {
     Write-Host "  Processing account: $account"
     $shortenedAccount = $account.Split("@")[0]
-    $userNameToSet = $navuserpasswordAuth ? $shortenedAccount : $account
+    $userNameToSet = $account
+    if ($navuserpasswordAuth) {
+        $userNameToSet = $shortenedAccount
+    }
 
     # Check if account already exists
     $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant $tenant | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -10,7 +10,7 @@ if ($env:auth -ieq "aad") {
     $navuserpasswordAuth = $false
 }
 
-$PermissionSet  = 'SUPER'
+$PermissionSet = "SUPER"
 
 $accounts = @($env:owner.Split(","))
 

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -1,0 +1,59 @@
+Write-Host "Handling multiple owners"
+
+if ($env:owner -eq $null) {
+    Write-Host "No owners found in env variable, skipping."
+    return
+}
+
+$navuserpasswordAuth = $true
+if ($env:auth -ieq "aad") {
+    $navuserpasswordAuth = $false
+}
+
+$accounts = @($env:owner.Split(","))
+
+foreach ($account in $accounts) {
+    Write-Host "  Processing account: $account"
+    $shortenedAccount = $account.Split("@")[0]
+    $userNameToSet = $navuserpasswordAuth ? $shortenedAccount : $account
+
+    # Check if account already exists
+    $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant $tenant | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
+    if($BcUser) {
+        '  User {0} already exists in the database.' -f $userNameToSet | Write-Host 
+
+        Set-NAVServerUser `
+            -ServerInstance $ServerInstance `
+            -UserName $userNameToSet `
+            -State Enabled `
+            -tenant $tenant `
+            -AuthenticationEmail $account
+
+        '  User {0} is now set to enabled.' -f $userNameToSet | Write-Host
+    } else {
+        New-NavServerUser `
+            -ServerInstance $ServerInstance `
+            -UserName $userNameToSet `
+            -tenant $tenant `
+            -AuthenticationEmail $account
+
+        '  Added user {0}  into Business Central.' -f $userNameToSet | Write-Host
+    }
+
+    # Set user permission set
+    $PermissionSetIDs = (Get-NAVServerUserPermissionSet `
+                        -UserName $userNameToSet `
+                        -tenant $tenant `
+                        -ServerInstance $ServerInstance).PermissionSetID
+    if ($PermissionSet -in $PermissionSetIDs) {
+        '  User {0} already has the PermissionSet {1}.' -f $userNameToSet, $PermissionSet | Write-Host
+    } else {
+        New-NavServerUserPermissionSet `
+            -ServerInstance  $ServerInstance `
+            -UserName $userNameToSet `
+            -tenant $tenant `
+            -PermissionSetId $PermissionSet
+
+        '  Added permission set {0} on user {1} in Business Central.' -f $PermissionSet, $userNameToSet | Write-Host
+    }
+}

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -14,6 +14,18 @@ $PermissionSet = "SUPER"
 
 $accounts = @($env:owner.Split(","))
 
+Write-Host "  Wait for container to be operational"
+for ($i = 0; $i -lt 60; $i++) {
+    $TenantState = (Get-NavTenant -ServerInstance BC -Tenant default).State
+    if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
+        break;
+    }
+
+    Write-Host "  Tenant not operational yet (try $i), sleeping 10s"
+    Start-Sleep -Seconds 10
+}
+
+
 foreach ($account in $accounts) {
     Write-Host "  Processing account: $account"
     $shortenedAccount = $account.Split("@")[0]

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -36,18 +36,22 @@ foreach ($account in $accounts) {
 
     # Check if account already exists
     $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant default | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
-    if($BcUser -and $BcUser.State -eq "Disabled") {
-        '  User {0} already exists in the database, but is disabled.' -f $userNameToSet | Write-Host 
+    if($BcUser) {
+        if ($BcUser.State -eq "Disabled") {
+            '  User {0} already exists in the database, but is disabled.' -f $userNameToSet | Write-Host 
 
-        Set-NAVServerUser `
-            -ServerInstance $ServerInstance `
-            -UserName $userNameToSet `
-            -State Enabled `
-            -tenant default `
-            -AuthenticationEmail $account `
-            -password $securePassword
+            Set-NAVServerUser `
+                -ServerInstance $ServerInstance `
+                -UserName $userNameToSet `
+                -State Enabled `
+                -tenant default `
+                -AuthenticationEmail $account `
+                -password $securePassword
 
-        '  User {0} is now set to enabled and has the default password.' -f $userNameToSet | Write-Host
+            '  User {0} is now set to enabled and has the default password.' -f $userNameToSet | Write-Host
+        } else {
+            '  User {0} already exists in the database and is enabled, doing nothing.' -f $userNameToSet | Write-Host 
+        }
     } else {
         '  User {0} does not exist in the database.' -f $userNameToSet | Write-Host 
         if ($navuserpasswordAuth) {

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -16,7 +16,7 @@ $accounts = @($env:owner.Split(","))
 
 Write-Host "  Wait for container to be operational"
 for ($i = 0; $i -lt 60; $i++) {
-    $TenantState = (Get-NavTenant -ServerInstance BC -Tenant default).State
+    $TenantState = (Get-NavTenant -ServerInstance BC -Tenant $tenantId).State
     if (($TenantState -eq "Mounted") -or ($TenantState -eq "Operational")) {
         break;
     }
@@ -35,7 +35,7 @@ foreach ($account in $accounts) {
     }
 
     # Check if account already exists
-    $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant default | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
+    $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant $tenantId | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
     if($BcUser) {
         if ($BcUser.State -eq "Disabled") {
             '  User {0} already exists in the database, but is disabled.' -f $userNameToSet | Write-Host 
@@ -44,7 +44,7 @@ foreach ($account in $accounts) {
                 -ServerInstance $ServerInstance `
                 -UserName $userNameToSet `
                 -State Enabled `
-                -tenant default `
+                -tenant $tenantId `
                 -AuthenticationEmail $account `
                 -password $securePassword
 
@@ -59,13 +59,13 @@ foreach ($account in $accounts) {
             New-NavServerUser `
                 -ServerInstance $ServerInstance `
                 -UserName $userNameToSet `
-                -tenant default `
+                -tenant $tenantId `
                 -password $securePassword
         } else {
             New-NavServerUser `
                 -ServerInstance $ServerInstance `
                 -UserName $userNameToSet `
-                -tenant default `
+                -tenant $tenantId `
                 -AuthenticationEmail $account
         }
 
@@ -75,7 +75,7 @@ foreach ($account in $accounts) {
     # Set user permission set
     $PermissionSetIDs = (Get-NAVServerUserPermissionSet `
                         -UserName $userNameToSet `
-                        -tenant default `
+                        -tenant $tenantId `
                         -ServerInstance $ServerInstance).PermissionSetID
     if ($PermissionSet -in $PermissionSetIDs) {
         '  User {0} already has the PermissionSet {1}.' -f $userNameToSet, $PermissionSet | Write-Host
@@ -83,7 +83,7 @@ foreach ($account in $accounts) {
         New-NavServerUserPermissionSet `
             -ServerInstance  $ServerInstance `
             -UserName $userNameToSet `
-            -tenant default `
+            -tenant $tenantId `
             -PermissionSetId $PermissionSet
 
         '  Added permission set {0} on user {1} in Business Central.' -f $PermissionSet, $userNameToSet | Write-Host

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -36,17 +36,18 @@ foreach ($account in $accounts) {
 
     # Check if account already exists
     $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant default | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
-    if($BcUser) {
-        '  User {0} already exists in the database.' -f $userNameToSet | Write-Host 
+    if($BcUser -and $BcUser.State -eq "Disabled") {
+        '  User {0} already exists in the database, but is disabled.' -f $userNameToSet | Write-Host 
 
         Set-NAVServerUser `
             -ServerInstance $ServerInstance `
             -UserName $userNameToSet `
             -State Enabled `
             -tenant default `
-            -AuthenticationEmail $account
+            -AuthenticationEmail $account `
+            -password $securePassword
 
-        '  User {0} is now set to enabled.' -f $userNameToSet | Write-Host
+        '  User {0} is now set to enabled and has the default password.' -f $userNameToSet | Write-Host
     } else {
         '  User {0} does not exist in the database.' -f $userNameToSet | Write-Host 
         if ($navuserpasswordAuth) {

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -21,7 +21,7 @@ foreach ($account in $accounts) {
     }
 
     # Check if account already exists
-    $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant $tenant | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
+    $BcUser = Get-NAVServerUser -ServerInstance $ServerInstance -tenant default | Where-Object { $_.UserName -ieq $shortenedAccount -or $_.UserName -like "$($shortenedAccount)@*" }
     if($BcUser) {
         '  User {0} already exists in the database.' -f $userNameToSet | Write-Host 
 
@@ -29,16 +29,24 @@ foreach ($account in $accounts) {
             -ServerInstance $ServerInstance `
             -UserName $userNameToSet `
             -State Enabled `
-            -tenant $tenant `
+            -tenant default `
             -AuthenticationEmail $account
 
         '  User {0} is now set to enabled.' -f $userNameToSet | Write-Host
     } else {
-        New-NavServerUser `
-            -ServerInstance $ServerInstance `
-            -UserName $userNameToSet `
-            -tenant $tenant `
-            -AuthenticationEmail $account
+        if ($navuserpasswordAuth) {
+            New-NavServerUser `
+                -ServerInstance $ServerInstance `
+                -UserName $userNameToSet `
+                -tenant default `
+                -password (ConvertTo-SecureString -String $env:password -AsPlainText -Force)
+        } else {
+            New-NavServerUser `
+                -ServerInstance $ServerInstance `
+                -UserName $userNameToSet `
+                -tenant default `
+                -AuthenticationEmail $account
+        }
 
         '  Added user {0}  into Business Central.' -f $userNameToSet | Write-Host
     }
@@ -46,7 +54,7 @@ foreach ($account in $accounts) {
     # Set user permission set
     $PermissionSetIDs = (Get-NAVServerUserPermissionSet `
                         -UserName $userNameToSet `
-                        -tenant $tenant `
+                        -tenant default `
                         -ServerInstance $ServerInstance).PermissionSetID
     if ($PermissionSet -in $PermissionSetIDs) {
         '  User {0} already has the PermissionSet {1}.' -f $userNameToSet, $PermissionSet | Write-Host
@@ -54,7 +62,7 @@ foreach ($account in $accounts) {
         New-NavServerUserPermissionSet `
             -ServerInstance  $ServerInstance `
             -UserName $userNameToSet `
-            -tenant $tenant `
+            -tenant default `
             -PermissionSetId $PermissionSet
 
         '  Added permission set {0} on user {1} in Business Central.' -f $PermissionSet, $userNameToSet | Write-Host

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -1,6 +1,6 @@
 Write-Host "Handling multiple owners"
 
-if ($env:owner -eq $null) {
+if ($env:owner -eq $null -or $env:owner -eq "") {
     Write-Host "No owners found in env variable, skipping."
     return
 }

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -48,12 +48,13 @@ foreach ($account in $accounts) {
 
         '  User {0} is now set to enabled.' -f $userNameToSet | Write-Host
     } else {
+        '  User {0} does not exist in the database.' -f $userNameToSet | Write-Host 
         if ($navuserpasswordAuth) {
             New-NavServerUser `
                 -ServerInstance $ServerInstance `
                 -UserName $userNameToSet `
                 -tenant default `
-                -password (ConvertTo-SecureString -String $env:password -AsPlainText -Force)
+                -password $securePassword
         } else {
             New-NavServerUser `
                 -ServerInstance $ServerInstance `

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -51,6 +51,7 @@ foreach ($account in $accounts) {
             '  User {0} is now set to enabled and has the default password.' -f $userNameToSet | Write-Host
         } else {
             '  User {0} already exists in the database and is enabled, doing nothing.' -f $userNameToSet | Write-Host 
+            continue
         }
     } else {
         '  User {0} does not exist in the database.' -f $userNameToSet | Write-Host 

--- a/misc/AdditionalSetupDuplicateUsers.ps1
+++ b/misc/AdditionalSetupDuplicateUsers.ps1
@@ -1,6 +1,6 @@
 Write-Host "Finding users with duplicate AuthenticationEmail and fixing disabled duplicate users"
 
-$duplicateAadUserSets = Get-NAVServerUser -ServerInstance $ServerInstance -Tenant "default" | where { $_.AuthenticationEmail -ne '' } | group 'AuthenticationEmail' | Where { $_.Count -gt 1 } 
+$duplicateAadUserSets = Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | where { $_.AuthenticationEmail -ne '' } | group 'AuthenticationEmail' | Where { $_.Count -gt 1 } 
 
 foreach ($duplicateAadUserSet in $duplicateAadUserSets)
 {
@@ -11,7 +11,7 @@ foreach ($duplicateAadUserSet in $duplicateAadUserSets)
         # moving to a non-existent email as removing doesn't work
         if ($disabledDuplicateUser.UserName) {
             Write-Host "Fixing AuthenticationEmail of duplicate user $($disabledDuplicateUser.UserName)"
-            Set-NAVServerUser -Tenant "default" -ServerInstance $ServerInstance -UserName $disabledDuplicateUser.UserName -AuthenticationEmail "none@example.com" -State Disabled
+            Set-NAVServerUser -Tenant $tenantId -ServerInstance $ServerInstance -UserName $disabledDuplicateUser.UserName -AuthenticationEmail "none@example.com" -State Disabled
         }
     }
 }


### PR DESCRIPTION
Additional owners are also set up as users, respecting the auth mode of the container. If the user already exists in the database (e.g. because the container used a bak or bacpac) and is disabled, it is enabled and the password is set for NavUserPassword mode. If the user came from a different domain (after the @ in the auth email), that is corrected. If the user exists and is enabled, nothing is done