### PR TITLE
use `url` to identify if a mod. base app is going to be installed as `name` could be anything

### DIFF
--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -176,7 +176,7 @@ if ($global:cosmoRunspacePool) {
     }
 }
 
-$installModifiedBaseAppManually = $null -ne ( $global:cosmoArtifacts.Artifacts.All | Where-Object { $null -ne $_.name -and $_.name -like "*_4PS Construct ??_*" } )
+$installModifiedBaseAppManually = $null -ne ( $global:cosmoArtifacts.Artifacts.All | Where-Object { $null -ne $_.url -and [System.IO.Path]::GetFileName($_.url) -like "*_4PS Construct ??_*" } )
 $installModifiedBaseAppManually = $installModifiedBaseAppManually -or ![string]::IsNullOrEmpty($env:systemAppOnly)
 
 # Initialize company


### PR DESCRIPTION
The name of an artifact could also be `*` or something similar. Therefore I'd like to switch to using the URL which contains the app name