### PR TITLE
4ps k8s mdo bus found

### DIFF
--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -213,6 +213,16 @@ if ((![string]::IsNullOrEmpty($env:saasbakfile) -or $installModifiedBaseAppManua
     Sync-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Mode ForceSync
     Write-Host "  Install the system application"
     Install-NAVApp -ServerInstance BC -Name "System Application" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+
+    # Publish Microsoft Business Foundation App for 26x and higher
+    if ($sysAppInfoFS.Version.Major -ge "26") {
+        Write-Host "  Publish the Business Foundation $($sysAppInfoFS.Version)"
+        Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\BusinessFoundation\Source\Microsoft_Business Foundation.app'
+        Write-Host "  Sync the Business Foundation with ForceSync"
+        Sync-NAVApp -ServerInstance BC -Name "Business Foundation" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Mode ForceSync
+        Write-Host "  Install the Business Foundation"
+        Install-NAVApp -ServerInstance BC -Name "Business Foundation" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
+    }
 }
 
 # Import Artifacts

--- a/artifacts/AdditionalSetupArtifacts.ps1
+++ b/artifacts/AdditionalSetupArtifacts.ps1
@@ -219,7 +219,7 @@ if ((![string]::IsNullOrEmpty($env:saasbakfile) -or $installModifiedBaseAppManua
         Write-Host "  Publish the Business Foundation $($sysAppInfoFS.Version)"
         Publish-NAVApp -ServerInstance BC -Path 'C:\Applications\BusinessFoundation\Source\Microsoft_Business Foundation.app'
         Write-Host "  Sync the Business Foundation with ForceSync"
-        Sync-NAVApp -ServerInstance BC -Name "Business Foundation" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Mode ForceSync
+        Sync-NAVApp -ServerInstance BC -Name "Business Foundation" -Publisher "Microsoft" -Version $sysAppInfoFS.Version -Mode ForceSync -Force
         Write-Host "  Install the Business Foundation"
         Install-NAVApp -ServerInstance BC -Name "Business Foundation" -Publisher "Microsoft" -Version $sysAppInfoFS.Version
     }


### PR DESCRIPTION
Install business foundation from microsoft automatically just like system application when the version is 26x or higher. 
We will switch back to standard business foundation for version 26x and higher.
The business foundation is published when creating the backup bak file.