### PR TITLE
feat(nuget): Read trusted nuget feeds managed by the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@
 - Fixed wrong missing PAT warning
 - Fixed issue with multiple custom nuget feeds
 - Stabilize SSH download and go to latest beta release of OpenSSH
+- Add support for managing all nuget feeds by backend (and keep it backward compatible)

--- a/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
@@ -22,41 +22,36 @@
                         $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
                     }
             }
-            if ($feeds.Count -eq 0) {
-                Write-Host "- No NuGet feeds found"
-            }
-            return;
-        }
-
-        Write-Host "Collecting Microsoft NuGet feeds"
-        @( 
-            "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSApps/nuget/v3/index.json"
-        ) | 
-            ForEach-Object {
-                Write-Host "- Adding NuGet feed: $_"
-                $feeds += Initialize-NuGetFeed -Url $_
-            }
-
-        if ($global:extendedEnv.CustomNugetFeeds) {            
-            Write-Host "Collecting custom nuget feeds"
-            $customNugetFeedsBase64 = $global:extendedEnv.CustomNugetFeeds
-            $customNugetFeedsJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($customNugetFeedsBase64))
-            ($customNugetFeedsJson | ConvertFrom-Json) |
-                Where-Object { $_ } |
+        } else {
+            Write-Host "Collecting Microsoft NuGet feeds"
+            @( 
+                "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSApps/nuget/v3/index.json"
+            ) | 
                 ForEach-Object {
-                    $url = $_.feedUrl
-                    if ($url -in @( $feeds.Url )) {
-                        Write-Host "- NuGet feed already added: $url - Skipping"
-                    } else {
-                        Write-Host "- Adding NuGet feed: $url"
-                        $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
-                    }
+                    Write-Host "- Adding NuGet feed: $_"
+                    $feeds += Initialize-NuGetFeed -Url $_
                 }
+
+            if ($global:extendedEnv.CustomNugetFeeds) {            
+                Write-Host "Collecting custom nuget feeds"
+                $customNugetFeedsBase64 = $global:extendedEnv.CustomNugetFeeds
+                $customNugetFeedsJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($customNugetFeedsBase64))
+                ($customNugetFeedsJson | ConvertFrom-Json) |
+                    Where-Object { $_ } |
+                    ForEach-Object {
+                        $url = $_.feedUrl
+                        if ($url -in @( $feeds.Url )) {
+                            Write-Host "- NuGet feed already added: $url - Skipping"
+                        } else {
+                            Write-Host "- Adding NuGet feed: $url"
+                            $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
+                        }
+                    }
+            }
         }
 
         @(
-            "C:\Run\my\trusted-nuget-feeds\trustedFeeds.json", 
-            "C:\Run\my\trusted-nuget-feeds\customTrustedFeeds.json"
+            "C:\Run\my\trusted-nuget-feeds\trustedFeeds.json"
         ) |
             Where-Object { Test-Path $_ -PathType Leaf } |
             ForEach-Object {

--- a/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
@@ -9,12 +9,12 @@
     }
 
     process {
-        if ($global:extendedEnv.PSObject.Properties.Name -contains "TrustedNugetFeeds") {
+        if ($global:extendedEnv.PSObject.Properties.Name -contains "TrustedNuGetFeeds") {
             Write-Host "Collecting trusted nuget feeds"
-            if ($global:extendedEnv.TrustedNugetFeeds) {
-                $trustedNugetFeedsBase64 = $global:extendedEnv.TrustedNugetFeeds
-                $trustedNugetFeedsJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($trustedNugetFeedsBase64))
-                ($trustedNugetFeedsJson | ConvertFrom-Json) |
+            if ($global:extendedEnv.TrustedNuGetFeeds) {
+                $trustedNuGetFeedsBase64 = $global:extendedEnv.TrustedNuGetFeeds
+                $trustedNuGetFeedsJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($trustedNuGetFeedsBase64))
+                ($trustedNuGetFeedsJson | ConvertFrom-Json) |
                     Where-Object { $_ } |
                     ForEach-Object {
                         $url = $_.feedUrl

--- a/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
@@ -9,18 +9,32 @@
     }
 
     process {
+        if ($global:extendedEnv.PSObject.Properties.Name -contains "TrustedNugetFeeds") {
+            Write-Host "Collecting trusted nuget feeds"
+            if ($global:extendedEnv.TrustedNugetFeeds) {
+                $trustedNugetFeedsBase64 = $global:extendedEnv.TrustedNugetFeeds
+                $trustedNugetFeedsJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($trustedNugetFeedsBase64))
+                ($trustedNugetFeedsJson | ConvertFrom-Json) |
+                    Where-Object { $_ } |
+                    ForEach-Object {
+                        $url = $_.feedUrl
+                        Write-Host "- Adding NuGet feed: $url"
+                        $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
+                    }
+            }
+            if ($feeds.Count -eq 0) {
+                Write-Host "- No NuGet feeds found"
+            }
+            return;
+        }
+
         Write-Host "Collecting Microsoft NuGet feeds"
         @( 
             "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSApps/nuget/v3/index.json"
         ) | 
             ForEach-Object {
-                Write-Host "Adding NuGet feed: $_"
-                $feeds += [PSCustomObject]@{ 
-                    Url          = $_
-                    Token        = ""
-                    Patterns     = @('*')
-                    Fingerprints = @() 
-                }
+                Write-Host "- Adding NuGet feed: $_"
+                $feeds += Initialize-NuGetFeed -Url $_
             }
 
         if ($global:extendedEnv.CustomNugetFeeds) {            
@@ -32,15 +46,10 @@
                 ForEach-Object {
                     $url = $_.feedUrl
                     if ($url -in @( $feeds.Url )) {
-                        Write-Host "NuGet feed already added: $url - Skipping"
+                        Write-Host "- NuGet feed already added: $url - Skipping"
                     } else {
-                        Write-Host "Adding NuGet feed: $url"
-                        $feeds += [PSCustomObject]@{ 
-                            Url          = $url
-                            Token        = $_.pat
-                            Patterns     = @('*')
-                            Fingerprints = @()
-                        }
+                        Write-Host "- Adding NuGet feed: $url"
+                        $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
                     }
                 }
         }
@@ -58,15 +67,10 @@
             ForEach-Object {
                 $url = $_.url
                 if ($url -in @( $feeds.Url )) {
-                    Write-Host "NuGet feed already added: $url - Skipping"
+                    Write-Host "- NuGet feed already added: $url - Skipping"
                 } else {
-                    Write-Host "Adding NuGet feed: $url"
-                    $feeds += [PSCustomObject]@{ 
-                        Url          = $url
-                        Token        = $_.pat
-                        Patterns     = @('*')
-                        Fingerprints = @()
-                    }
+                    Write-Host "- Adding NuGet feed: $url"
+                    $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
                 }
             }
     }
@@ -80,3 +84,37 @@
     }
 }
 Export-ModuleMember -Function Initialize-NuGetFeeds
+
+function Initialize-NuGetFeed {
+    [cmdletbinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+        [Parameter(Mandatory = $false)]
+        [string]$Token = "",
+        [Parameter(Mandatory = $false)]
+        [string]$TokenGitHubSecret = $null,
+        [Parameter(Mandatory = $false)]
+        [string[]]$Patterns = @('*'),
+        [Parameter(Mandatory = $false)]
+        [string[]]$Fingerprints = @()
+    )
+
+    $feed = @{
+        Url          = $Url
+        Token        = $Token
+        Patterns     = $Patterns
+        Fingerprints = $Fingerprints
+    }
+
+    if ($TokenGitHubSecret) {
+        # TODO: Get github secret
+        if ($githubToken) {
+            $feed.Token = $githubToken
+        } else {
+            Write-Host "Warning: Could not retrieve GitHub secret '$TokenGitHubSecret' for NuGet feed '$Url'"
+        }
+    }
+
+    return [PSCustomObject]$feed
+}

--- a/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Initialize-NuGetFeeds.ps1
@@ -19,7 +19,7 @@
                     ForEach-Object {
                         $url = $_.feedUrl
                         Write-Host "- Adding NuGet feed: $url"
-                        $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
+                        $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat
                     }
             }
         } else {
@@ -44,7 +44,7 @@
                             Write-Host "- NuGet feed already added: $url - Skipping"
                         } else {
                             Write-Host "- Adding NuGet feed: $url"
-                            $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
+                            $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat
                         }
                     }
             }
@@ -65,7 +65,7 @@
                     Write-Host "- NuGet feed already added: $url - Skipping"
                 } else {
                     Write-Host "- Adding NuGet feed: $url"
-                    $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat -TokenGitHubSecret $_.patGitHubSecret
+                    $feeds += Initialize-NuGetFeed -Url $url -Token $_.pat
                 }
             }
     }
@@ -88,8 +88,6 @@ function Initialize-NuGetFeed {
         [Parameter(Mandatory = $false)]
         [string]$Token = "",
         [Parameter(Mandatory = $false)]
-        [string]$TokenGitHubSecret = $null,
-        [Parameter(Mandatory = $false)]
         [string[]]$Patterns = @('*'),
         [Parameter(Mandatory = $false)]
         [string[]]$Fingerprints = @()
@@ -100,15 +98,6 @@ function Initialize-NuGetFeed {
         Token        = $Token
         Patterns     = $Patterns
         Fingerprints = $Fingerprints
-    }
-
-    if ($TokenGitHubSecret) {
-        # TODO: Get github secret
-        if ($githubToken) {
-            $feed.Token = $githubToken
-        } else {
-            Write-Host "Warning: Could not retrieve GitHub secret '$TokenGitHubSecret' for NuGet feed '$Url'"
-        }
     }
 
     return [PSCustomObject]$feed


### PR DESCRIPTION
Implements [AB#4574](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4574)

- Removed reading NuGet feeds from mounted "customTrustedFeeds.json"
- Added new extended env "TrustedNugetFeeds" for nuget feeds managed by the backed
  - Includes backward compatibility in case new extended env is not given