### PR TITLE
fix(NuGet): prevent duplicate installedApps by keeping the highest version

### DIFF
--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -84,6 +84,7 @@ function Invoke-NuGetPackageDownload() {
             }
 
             if ($InstalledAppsPath -and (Test-Path -Path $InstalledAppsPath)) {
+                $appsById = @{}
                 Get-ChildItem -Path $InstalledAppsPath -Filter '*.app' -Recurse |
                     ForEach-Object { Get-NavAppInfo -Path $_.FullName } |
                     ForEach-Object {
@@ -96,21 +97,21 @@ function Invoke-NuGetPackageDownload() {
                         }
 
                         # Check if app with same Id already exists
-                        $existingApp = $downloadParameters.installedApps | Where-Object { $_.Id -eq $installedApp.Id }
-                        if ($existingApp) {
+                        if ($appsById.ContainsKey($installedApp.Id)) {
+                            $existingApp = $appsById[$installedApp.Id]
                             # Keep the one with the highest version
                             if ([Version]$installedApp.Version -gt [Version]$existingApp.Version) {
                                 Write-Host "Replacing app with higher version: $($installedApp.Package) (version: $($installedApp.Version) > $($existingApp.Version))"
-                                $downloadParameters.installedApps = @($downloadParameters.installedApps | Where-Object { $_.Id -ne $installedApp.Id })
-                                $downloadParameters.installedApps += $installedApp
+                                $appsById[$installedApp.Id] = $installedApp
                             } else {
                                 Write-Host "Skipping duplicate app with lower or equal version: $($installedApp.Package) (version: $($installedApp.Version) <= $($existingApp.Version))"
                             }
                         } else {
                             Write-Host "Use app file as installed app: $($installedApp.Package) (version: $($installedApp.Version))"
-                            $downloadParameters.installedApps += $installedApp
+                            $appsById[$installedApp.Id] = $installedApp
                         }
                     }
+                $downloadParameters.installedApps = @($appsById.Values)
             }
 
             foreach ($predefinedPackage in $PredefinedPackages) {

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -84,7 +84,7 @@ function Invoke-NuGetPackageDownload() {
             }
 
             if ($InstalledAppsPath -and (Test-Path -Path $InstalledAppsPath)) {
-                $appsById = @{}
+                $installedAppsById = @{}
                 Get-ChildItem -Path $InstalledAppsPath -Filter '*.app' -Recurse |
                     ForEach-Object { Get-NavAppInfo -Path $_.FullName } |
                     ForEach-Object {
@@ -97,21 +97,21 @@ function Invoke-NuGetPackageDownload() {
                         }
 
                         # Check if app with same Id already exists
-                        if ($appsById.ContainsKey($installedApp.Id)) {
-                            $existingApp = $appsById[$installedApp.Id]
+                        if ($installedAppsById.ContainsKey($installedApp.Id)) {
+                            $existingApp = $installedAppsById[$installedApp.Id]
                             # Keep the one with the highest version
                             if ([Version]$installedApp.Version -gt [Version]$existingApp.Version) {
                                 Write-Host "Replacing app with higher version: $($installedApp.Package) (version: $($installedApp.Version) > $($existingApp.Version))"
-                                $appsById[$installedApp.Id] = $installedApp
+                                $installedAppsById[$installedApp.Id] = $installedApp
                             } else {
                                 Write-Host "Skipping duplicate app with lower or equal version: $($installedApp.Package) (version: $($installedApp.Version) <= $($existingApp.Version))"
                             }
                         } else {
                             Write-Host "Use app file as installed app: $($installedApp.Package) (version: $($installedApp.Version))"
-                            $appsById[$installedApp.Id] = $installedApp
+                            $installedAppsById[$installedApp.Id] = $installedApp
                         }
                     }
-                $downloadParameters.installedApps = @($appsById.Values)
+                $downloadParameters.installedApps = @($installedAppsById.Values)
             }
 
             foreach ($predefinedPackage in $PredefinedPackages) {

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -84,34 +84,24 @@ function Invoke-NuGetPackageDownload() {
             }
 
             if ($InstalledAppsPath -and (Test-Path -Path $InstalledAppsPath)) {
-                $installedAppsById = @{}
-                Get-ChildItem -Path $InstalledAppsPath -Filter '*.app' -Recurse |
+                $installedApps = Get-ChildItem -Path $InstalledAppsPath -Filter '*.app' -Recurse |
                     ForEach-Object { Get-NavAppInfo -Path $_.FullName } |
                     ForEach-Object {
-                        $installedApp = [PSCustomObject]@{
+                        [PSCustomObject]@{
                             Package   = '{0}.{1}.{2}' -f $_.Publisher, $_.Name, $_.AppId -replace ' '
                             Name      = $_.Name
                             Publisher = $_.Publisher
                             Id        = $_.AppId
                             Version   = $_.Version
                         }
-
-                        # Check if app with same Id already exists
-                        if ($installedAppsById.ContainsKey($installedApp.Id)) {
-                            $existingApp = $installedAppsById[$installedApp.Id]
-                            # Keep the one with the highest version
-                            if ([Version]$installedApp.Version -gt [Version]$existingApp.Version) {
-                                Write-Host "Replacing app with higher version: $($installedApp.Package) (version: $($installedApp.Version) > $($existingApp.Version))"
-                                $installedAppsById[$installedApp.Id] = $installedApp
-                            } else {
-                                Write-Host "Skipping duplicate app with lower or equal version: $($installedApp.Package) (version: $($installedApp.Version) <= $($existingApp.Version))"
-                            }
-                        } else {
-                            Write-Host "Use app file as installed app: $($installedApp.Package) (version: $($installedApp.Version))"
-                            $installedAppsById[$installedApp.Id] = $installedApp
-                        }
+                    } |
+                    Group-Object -Property Id |
+                    ForEach-Object {
+                        $highestVersion = $_.Group | Sort-Object -Property { [Version]$_.Version } -Descending | Select-Object -First 1
+                        Write-Host "Use app file as installed app: $($highestVersion.Package) (version: $($highestVersion.Version))"
+                        $highestVersion
                     }
-                $downloadParameters.installedApps = @($installedAppsById.Values)
+                $downloadParameters.installedApps = @($installedApps)
             }
 
             foreach ($predefinedPackage in $PredefinedPackages) {

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -95,8 +95,21 @@ function Invoke-NuGetPackageDownload() {
                             Version   = $_.Version
                         }
 
-                        Write-Host "Use app file as installed app: $($installedApp.Package) (version: $($installedApp.Version))"
-                        $downloadParameters.installedApps += $installedApp
+                        # Check if app with same Id already exists
+                        $existingApp = $downloadParameters.installedApps | Where-Object { $_.Id -eq $installedApp.Id }
+                        if ($existingApp) {
+                            # Keep the one with the highest version
+                            if ([Version]$installedApp.Version -gt [Version]$existingApp.Version) {
+                                Write-Host "Replacing app with higher version: $($installedApp.Package) (version: $($installedApp.Version) > $($existingApp.Version))"
+                                $downloadParameters.installedApps = @($downloadParameters.installedApps | Where-Object { $_.Id -ne $installedApp.Id })
+                                $downloadParameters.installedApps += $installedApp
+                            } else {
+                                Write-Host "Skipping duplicate app with lower or equal version: $($installedApp.Package) (version: $($installedApp.Version) <= $($existingApp.Version))"
+                            }
+                        } else {
+                            Write-Host "Use app file as installed app: $($installedApp.Package) (version: $($installedApp.Version))"
+                            $downloadParameters.installedApps += $installedApp
+                        }
                     }
             }
 


### PR DESCRIPTION
Duplicate entries in the installedApps cause an error in BCCH when downloading NuGet packages.
fixes [AB#4615](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4615)


```powershell
...
[INFO] Download Artifact from NuGet package CosmoConsult.COSMOAdvancedManufacturingPack.1b26c6f6-4689-4dc3-af55-f39e95a781f8
...
[INFO] Use app file as installed app: CosmoConsult.COSMOAdvancedManufacturingPack.1b26c6f6-4689-4dc3-af55-f39e95a781f8 (version: 12.2.320329.0)
[INFO] Use app file as installed app: CosmoConsult.COSMOAdvancedManufacturingPack.1b26c6f6-4689-4dc3-af55-f39e95a781f8 (version: 12.2.320329.0)
...
[INFO] Looking for NuGet package CosmoConsult.COSMOAdvancedManufacturingPack.1b26c6f6-4689-4dc3-af55-f39e95a781f8 version 0.0.0.0 (LatestMatching match)
[INFO] Error Message: Cannot convert value "12.2.320329.0 12.2.320329.0" to type "System.Version". Error: "Version string portion was too short or too long."
[INFO] StackTrace: at NormalizeVersionStr, C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\bccontainerhelper\6.1.10\NuGet\NuGetFeedClass.ps1: line 240
[INFO] at IsVersionIncludedInRange, C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\bccontainerhelper\6.1.10\NuGet\NuGetFeedClass.ps1: line 273
[INFO] at Download-BcNuGetPackageToFolder, C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\bccontainerhelper\6.1.10\NuGet\Download-BcNuGetPackageToFolder.ps1: line 132
[INFO] at Invoke-NuGetPackageDownload<Process>, C:\run\ArtifactHandling\NuGet\Invoke-NuGetPackageDownload.ps1: line 156
[INFO] at Invoke-DownloadArtifactCore<Process>, C:\run\ArtifactHandling\Invoke-DownloadArtifactCore.ps1: line 264
[INFO] at Invoke-DownloadArtifact<End>, C:\run\ArtifactHandling\Invoke-DownloadArtifact.ps1: line 100
[INFO] at <ScriptBlock>, C:\Run\my\navstartArtifacts.ps1: line 147
[INFO] at <ScriptBlock>, C:\Run\my\navstartArtifacts.ps1: line 143
[INFO] at <ScriptBlock>, C:\Run\my\navstart.ps1: line 19
[INFO] at <ScriptBlock>, C:\Run\start.ps1: line 391
[INFO] at <ScriptBlock>, <No file>: line 1
...
```