### PR TITLE
fix(NavAppManagement): enable PSRemoting for PowerShell Core in BC28

### DIFF
--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -31,8 +31,7 @@ if ($bcVersion.Major -ge 28) {
     }
     Invoke-PwshOverwriting -commandNames $commandNames
     
-    Write-Host "Enabling PSRemoting for PowerShell Core (pwsh)"
-    pwsh -Command 'Enable-PSRemoting -wa SilentlyContinue'
+    Get-PwshCoreSessionConfiguration | Out-Null
 }
 else {
     # Create powershell core remote session (may enable remoting for powershell core)

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -30,6 +30,9 @@ if ($bcVersion.Major -ge 28) {
         throw "PowerShell Core ('pwsh') is required but was not found. Ensure that PowerShell Core is installed and 'pwsh' is available on PATH."
     }
     Invoke-PwshOverwriting -commandNames $commandNames
+    
+    Write-Host "Enabling PSRemoting for PowerShell Core (pwsh)"
+    pwsh -Command 'Enable-PSRemoting -wa SilentlyContinue'
 }
 else {
     # Create powershell core remote session (may enable remoting for powershell core)


### PR DESCRIPTION
This pull request adds a step to enable PowerShell Remoting for PowerShell Core (`pwsh`) in the `NavAppManagement.ps1` script when the Business Central version is 28 or higher. This ensures that remoting capabilities are set up automatically if needed.

Enhancement to PowerShell Core remoting setup:

* Added a command to enable PSRemoting for PowerShell Core (`pwsh`) by running `Enable-PSRemoting` with warnings silenced, improving automation and reducing manual setup requirements.
part of [AB#4704](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4704)