### PR TITLE
Overwrite Mount-NavTenant to execute in pwsh core

### DIFF
--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -18,7 +18,6 @@ if (! (Get-Module 'PPIPowershellCoreUtils')) {
         'Start-NAVAppDataUpgrade', 
         'Sync-NAVApp', 
         'Uninstall-NAVApp', 
-        'Mount-NAVTenant',
         'Unpublish-NAVApp'
     ) 
 
@@ -44,4 +43,6 @@ else {
     $commandNames | ForEach-Object {
         Export-PwshCoreOverride -CommandName $_ -ModuleName $moduleName -ModuleImportScriptBlock $moduleImportScriptBlock
     }
+
+    Export-PwshCoreOverride -CommandName 'Mount-NAVTenant' -ModuleName 'Microsoft.BusinessCentral.Management' -ModuleImportScriptBlock $moduleImportScriptBlock
 }

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -18,6 +18,7 @@ if (! (Get-Module 'PPIPowershellCoreUtils')) {
         'Start-NAVAppDataUpgrade', 
         'Sync-NAVApp', 
         'Uninstall-NAVApp', 
+        'Mount-NAVTenant',
         'Unpublish-NAVApp'
     ) 
 

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -9,17 +9,21 @@ if (! (Get-Module 'PPIPowershellCoreUtils')) {
     Import-Module "c:\run\helper\PPIPowershellCoreUtils\PPIPowershellCoreUtils.psm1" -Global -Force
 }
 
- $commandNames = @(
-        'Get-NavAppRuntimePackage', 
-        'Install-NAVApp', 
-        'Invoke-InplacePublishing', 
-        'Publish-NAVApp', 
-        'Repair-NAVApp', 
-        'Start-NAVAppDataUpgrade', 
-        'Sync-NAVApp', 
-        'Uninstall-NAVApp', 
-        'Unpublish-NAVApp'
-    ) 
+$commandNamesForAppManagement = @(
+    'Get-NavAppRuntimePackage', 
+    'Install-NAVApp', 
+    'Invoke-InplacePublishing', 
+    'Publish-NAVApp', 
+    'Repair-NAVApp', 
+    'Start-NAVAppDataUpgrade', 
+    'Sync-NAVApp', 
+    'Uninstall-NAVApp', 
+    'Unpublish-NAVApp'
+) 
+
+$commandNamesForManagement = @(
+    'Mount-NAVTenant'
+) 
 
 if ($bcVersion.Major -ge 28) {
     # Validate that PowerShell Core (pwsh) is available up front for the BC28+ path
@@ -29,7 +33,7 @@ if ($bcVersion.Major -ge 28) {
     catch {
         throw "PowerShell Core ('pwsh') is required but was not found. Ensure that PowerShell Core is installed and 'pwsh' is available on PATH."
     }
-    Invoke-PwshOverwriting -commandNames $commandNames
+    Invoke-PwshOverwriting -commandNames ($commandNamesForAppManagement + $commandNamesForManagement)
     
     Get-PwshCoreSessionConfiguration | Out-Null
 }
@@ -37,12 +41,13 @@ else {
     # Create powershell core remote session (may enable remoting for powershell core)
     Get-PwshCoreSessionConfiguration | Out-Null
 
-    $moduleName = 'Microsoft.BusinessCentral.Apps.Management'
     $moduleImportScriptBlock = { c:\run\prompt.ps1 -silent }
    
-    $commandNames | ForEach-Object {
-        Export-PwshCoreOverride -CommandName $_ -ModuleName $moduleName -ModuleImportScriptBlock $moduleImportScriptBlock
+    $commandNamesForAppManagement | ForEach-Object {
+        Export-PwshCoreOverride -CommandName $_ -ModuleName 'Microsoft.BusinessCentral.Apps.Management' -ModuleImportScriptBlock $moduleImportScriptBlock
     }
 
-    Export-PwshCoreOverride -CommandName 'Mount-NAVTenant' -ModuleName 'Microsoft.BusinessCentral.Management' -ModuleImportScriptBlock $moduleImportScriptBlock
+    $commandNamesForManagement | ForEach-Object {
+        Export-PwshCoreOverride -CommandName $_ -ModuleName 'Microsoft.BusinessCentral.Management' -ModuleImportScriptBlock $moduleImportScriptBlock
+    }
 }


### PR DESCRIPTION

This pull request refactors the way command names are managed and exported in the `NavAppManagement.ps1` script. The main improvement is splitting command names into two distinct groups for better clarity and modularity, and ensuring that commands are associated with their correct modules during export.

Grouping and modularity improvements:

* Split the original `$commandNames` array into `$commandNamesForAppManagement` and `$commandNamesForManagement`, separating app management commands from general management commands. [[1]](diffhunk://#diff-d9be982fba7fc07c1c187076d0629754734bfb0d83c1fb9c10c76580c7ae4af3L12-R12) [[2]](diffhunk://#diff-d9be982fba7fc07c1c187076d0629754734bfb0d83c1fb9c10c76580c7ae4af3R24-R27)
* Updated the PowerShell Core invocation to combine both command groups when calling `Invoke-PwshOverwriting`, ensuring all relevant commands are handled for BC28+ environments.

Module association enhancements:

* Modified the export logic to associate app management commands with the `Microsoft.BusinessCentral.Apps.Management` module and management commands with the `Microsoft.BusinessCentral.Management` module, improving module clarity and maintainability.

fixes [AB#4730](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4730)