### PR TITLE
fix(Get-ArtifactsFromEnvironment): redact PAT in log output for security

### DIFF
--- a/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
+++ b/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
@@ -62,7 +62,7 @@ function Get-ArtifactsFromEnvironment {
                     $artifactJson = '{"artifacts":[]}'
                 }
 
-                Write-Host "Artifacts: $($artifactJson -replace '("pat": ")(.*)(")','$1***REDACTED***$3')" # hide pat in logs
+                Write-Host "Artifacts: $($artifactJson -replace '("pat"\s*:\s*")[^"]*(")','$1***REDACTED***$2')" # hide pat in logs
                 $envArtifacts = ($artifactJson | ConvertFrom-Json -ErrorAction SilentlyContinue)
                 $artifacts = $envArtifacts.artifacts
                 if (! $artifacts) {

--- a/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
+++ b/artifacts/ArtifactHandling/Get-ArtifactsFromEnvironment.ps1
@@ -62,7 +62,7 @@ function Get-ArtifactsFromEnvironment {
                     $artifactJson = '{"artifacts":[]}'
                 }
 
-                Write-Host "Artifacts: $artifactJson"
+                Write-Host "Artifacts: $($artifactJson -replace '("pat": ")(.*)(")','$1***REDACTED***$3')" # hide pat in logs
                 $envArtifacts = ($artifactJson | ConvertFrom-Json -ErrorAction SilentlyContinue)
                 $artifacts = $envArtifacts.artifacts
                 if (! $artifacts) {


### PR DESCRIPTION
This pull request makes a small but important change to the logging behavior in the `Get-ArtifactsFromEnvironment` function. The change ensures that any personal access tokens (`pat`) present in artifact JSON data are redacted in the logs to prevent sensitive information from being exposed.

* Logging improvement:
  * Updated the `Write-Host` statement to redact the value of any `"pat"` fields in the artifact JSON output, replacing the actual token with `***REDACTED***` in logs.
 
fixes [AB#4724](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4724)