### PR TITLE
fix: download rapidstart artifacts to temp folder for BC file access

### DIFF
--- a/artifacts/ArtifactHandling/Import-Artifacts.ps1
+++ b/artifacts/ArtifactHandling/Import-Artifacts.ps1
@@ -150,9 +150,13 @@ function Import-Artifacts {
         }
 
         # Import RapidStart packages
+        $rapidStartPath = Join-Path ([System.IO.Path]::GetTempPath()) "rapidstart"
         $items = @()
+        if (Test-Path -LiteralPath $rapidStartPath) {
+            $items += @(Get-ChildItem -LiteralPath $rapidStartPath -Depth $maxDepth -Filter "*.rapidstart" -Recurse -ErrorAction SilentlyContinue)
+        }
         if (Test-Path -LiteralPath "$Path") {
-            $items = @() + (Get-ChildItem -LiteralPath "$Path" -Depth $maxDepth -Filter "*.rapidstart" -Recurse -ErrorAction SilentlyContinue)
+            $items += @(Get-ChildItem -LiteralPath "$Path" -Depth $maxDepth -Filter "*.rapidstart" -Recurse -ErrorAction SilentlyContinue)
         }
         if ($items) {
             try {

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -240,7 +240,7 @@ $invokeWebRequestSplat = @{
                         "font"        { $folder = "c:/fonts" }
                         "fonts"       { $folder = "c:/fonts" }
                         "demodata"    { $folder = "c:/demodata" }
-                        "rapidstart"  { $folder = Join-Path ([System.IO.Path]::GetTempPath()) "rapidstart/$folderSuffix" }
+                        "rapidstart"  { $folder = Join-Path (Join-Path ([System.IO.Path]::GetTempPath()) "rapidstart") $folderSuffix }
                         default    {
                             if (! $groupByDependency) {
                                 $folder = Join-Path $rootFolder "/$folderSuffix"

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -235,11 +235,12 @@ $invokeWebRequestSplat = @{
                     }
 
                     switch ("$target".ToLower()) {
-                        "dll"      { $folder = "$serviceTierFolder/Add-Ins/$folderSuffix" }
-                        "add-ins"  { $folder = "$serviceTierFolder/Add-Ins/$folderSuffix" }
-                        "font"     { $folder = "c:/fonts" }
-                        "fonts"    { $folder = "c:/fonts" }
-                        "demodata" { $folder = "c:/demodata" }
+                        "dll"         { $folder = "$serviceTierFolder/Add-Ins/$folderSuffix" }
+                        "add-ins"     { $folder = "$serviceTierFolder/Add-Ins/$folderSuffix" }
+                        "font"        { $folder = "c:/fonts" }
+                        "fonts"       { $folder = "c:/fonts" }
+                        "demodata"    { $folder = "c:/demodata" }
+                        "rapidstart"  { $folder = Join-Path ([System.IO.Path]::GetTempPath()) "rapidstart/$folderSuffix" }
                         default    {
                             if (! $groupByDependency) {
                                 $folder = Join-Path $rootFolder "/$folderSuffix"

--- a/artifacts/my/navstartArtifacts.ps1
+++ b/artifacts/my/navstartArtifacts.ps1
@@ -16,13 +16,14 @@ try {
             Sorted   = "C:\run\my\manuallysorted-apps";
         };
         Artifacts = @{
-            All      = @();
-            Unsorted = @();
-            Sorted   = @();
-            Backup   = @();
-            Font     = @();
-            AddIn    = @();
-            Demodata = @();
+            All        = @();
+            Unsorted   = @();
+            Sorted     = @();
+            Backup     = @();
+            Font       = @();
+            AddIn      = @();
+            Demodata   = @();
+            RapidStart = @();
         };
     }
 
@@ -39,8 +40,9 @@ try {
             if     ( $_.target -in @( "bak", "saasbak" ) )          { $cosmoArtifacts.Artifacts.Backup   += $_ }
             elseif ( $_.target -in @( "fonts", "font" ) )           { $cosmoArtifacts.Artifacts.Font     += $_ }
             elseif ( $_.target -in @( "add-ins", "dll" ) )          { $cosmoArtifacts.Artifacts.AddIn    += $_ }
-            elseif ( $_.target -in @( "demodata" ) )                { $cosmoArtifacts.Artifacts.Demodata += $_ }
-            elseif ( $_.name -and $_.name.StartsWith("sortorder") ) { $cosmoArtifacts.Artifacts.Sorted   += $_ }
+            elseif ( $_.target -in @( "demodata" ) )                { $cosmoArtifacts.Artifacts.Demodata   += $_ }
+            elseif ( $_.target -in @( "rapidstart" ) )             { $cosmoArtifacts.Artifacts.RapidStart += $_ }
+            elseif ( $_.name -and $_.name.StartsWith("sortorder") ) { $cosmoArtifacts.Artifacts.Sorted      += $_ }
             else                                                    { $cosmoArtifacts.Artifacts.Unsorted += $_ }
 
             if ($_.type -eq "nuget") {
@@ -77,12 +79,13 @@ try {
 
         # Add Runspaces to Cosmo Artifacts object
         $cosmoArtifacts.Download.Runspaces = @{
-            Unsorted = @();
-            Sorted   = @();
-            Backup   = @();
-            Font     = @();
-            AddIn    = @();
-            Demodata = @();
+            Unsorted   = @();
+            Sorted     = @();
+            Backup     = @();
+            Font       = @();
+            AddIn      = @();
+            Demodata   = @();
+            RapidStart = @();
         }
 
         # Download Add-In, Font and Demodata Artifacts (Async) - Start
@@ -97,6 +100,10 @@ try {
         Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.Demodata.Count) Demodata Artifacts (Async)"
         $cosmoArtifacts.Download.Runspaces.Demodata += 
             $cosmoArtifacts.Artifacts.Demodata |
+                Invoke-DownloadArtifactAsync -OneRunspace @downloadParameters
+        Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.RapidStart.Count) RapidStart Artifacts (Async)"
+        $cosmoArtifacts.Download.Runspaces.RapidStart += 
+            $cosmoArtifacts.Artifacts.RapidStart |
                 Invoke-DownloadArtifactAsync -OneRunspace @downloadParameters
 
         # Download sorted Artifacts (Async) - Start
@@ -126,11 +133,12 @@ try {
             ErrorAction     = "SilentlyContinue"
         }
 
-        # Download Add-In, Font and Demodata Artifacts
+        # Download Add-In, Font, Demodata and RapidStart Artifacts
         Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.AddIn.Count) Add-In Artifacts"
         Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.Font.Count) Font Artifacts"
         Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.Demodata.Count) Demodata Artifacts"
-        $( $cosmoArtifacts.Artifacts.AddIn; $cosmoArtifacts.Artifacts.Font; $cosmoArtifacts.Artifacts.Demodata ) | 
+        Add-ArtifactsLog -message "Download $($cosmoArtifacts.Artifacts.RapidStart.Count) RapidStart Artifacts"
+        $( $cosmoArtifacts.Artifacts.AddIn; $cosmoArtifacts.Artifacts.Font; $cosmoArtifacts.Artifacts.Demodata; $cosmoArtifacts.Artifacts.RapidStart ) | 
             Invoke-DownloadArtifact @downloadParameters
 
         # Download sorted Artifacts


### PR DESCRIPTION
Rapidstart files downloaded to C:\run\my\apps were inaccessible to BC codeunit 8620 (ImportAndApplyRapidStartPackage) because BC restricts file access to the current user's folder.

- Add 'rapidstart' target case in Invoke-DownloadArtifactCore to download .rapidstart files to the user temp folder
- Sort rapidstart artifacts separately in navstartArtifacts.ps1 (both async and sync download paths)
- Scan the temp rapidstart path in Import-Artifacts.ps1 in addition to the regular artifact path as fallback