### PR TITLE
Move extensions to dev endpoint for  dev containers

### DIFF
--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -318,7 +318,7 @@ function Invoke-4PSArtifactHandling {
 
                 
                 if ($env:IsBuildContainer -eq "false") {
-                    if ($env:AZURE_DEVOPS_PROJECT -eq '4PS_NL') {
+                    if ($env:movetodevscope -eq "true") {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `
                             -databaseServer $DatabaseServer `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -37,7 +37,8 @@ function Invoke-4PSMoveExtensionToDevScope {
                 ServerInstance = "$databaseServer\$databaseInstance"
                 ErrorAction    = "Stop"
             }
-            Invoke-Sqlcmd @sqlParams -Query "UPDATE [$databaseName].[dbo].[Published Application] SET [Published As] = 2, [Tenant ID] = 'default'" | Out-Null
+            $safeDb = $databaseName.Replace(']', ']]')
+            Invoke-Sqlcmd @sqlParams -Query "UPDATE [$safeDb].[dbo].[Published Application] SET [Published As] = 2, [Tenant ID] = 'default'" | Out-Null
         }
         catch {
             Write-Warning "Failed to move published apps to dev scope: $_. Continuing with current scope."
@@ -317,10 +318,12 @@ function Invoke-4PSArtifactHandling {
 
                 
                 if ($env:IsBuildContainer -eq "false") {
-                    Invoke-4PSMoveExtensionToDevScope `
-                        -databaseName $DatabaseName `
-                        -databaseServer $DatabaseServer `
-                        -databaseInstance $DatabaseInstance
+                    if ($env:AZURE_DEVOPS_PROJECT -eq '4PS_NL') {
+                        Invoke-4PSMoveExtensionToDevScope `
+                            -databaseName $DatabaseName `
+                            -databaseServer $DatabaseServer `
+                            -databaseInstance $DatabaseInstance   
+                    }
                 }
             }
         }

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -318,8 +318,7 @@ function Invoke-4PSArtifactHandling {
 
                 
                 if ($env:IsBuildContainer -eq "false") {
-                    Write-Host "Variable movetodevscope is set to '$($env:movetodevscope)', will move extensions to dev scope if it's set to 'true'"
-                    if ($env:movetodevscope -eq "true") {
+                   if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `
                             -databaseServer $DatabaseServer `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -315,7 +315,7 @@ function Invoke-4PSArtifactHandling {
                 
                 Write-Host "Moving all published apps to dev scope when possible"
                 if (-not $env:IsBuildContainer) {
-                    if ($env:AZURE_DEVOPS_PROJECT -eq '4PS_NL') {
+                    if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `
                             -databaseServer $DatabaseServer `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -1,6 +1,6 @@
 function Invoke-4PSMoveExtensionToDevScope {
     [cmdletbinding()]
-    PARAM
+    param
     (
         [parameter(Mandatory = $false)]
         [string]$databaseName,
@@ -9,7 +9,7 @@ function Invoke-4PSMoveExtensionToDevScope {
         [parameter(Mandatory = $false)]
         [string]$databaseInstance
     )
-    PROCESS {
+    process {
         try {
             $needsServerConfig = [string]::IsNullOrWhiteSpace($databaseName) -or [string]::IsNullOrWhiteSpace($databaseServer) -or [string]::IsNullOrWhiteSpace($databaseInstance)
 
@@ -314,13 +314,14 @@ function Invoke-4PSArtifactHandling {
                 
                 $timespent4PS = [Math]::Round([DateTime]::Now.Subtract($startTime4PS).Totalseconds)
                 Write-Host "  4PS initialization took $timespent4PS seconds"
-            }
 
-            if (-not ($env:IsBuildContainer -eq "true")) {
-                Invoke-4PSMoveExtensionToDevScope `
-                    -databaseName $DatabaseName `
-                    -databaseServer $DatabaseServer `
-                    -databaseInstance $DatabaseInstance
+                
+                if ($env:IsBuildContainer -eq "false") {
+                    Invoke-4PSMoveExtensionToDevScope `
+                        -databaseName $DatabaseName `
+                        -databaseServer $DatabaseServer `
+                        -databaseInstance $DatabaseInstance
+                }
             }
         }
     }

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -318,6 +318,7 @@ function Invoke-4PSArtifactHandling {
 
                 
                 if ($env:IsBuildContainer -eq "false") {
+                    Write-Host "Variable movetodevscope is set to '$($env:movetodevscope)', will move extensions to dev scope if it's set to 'true'"
                     if ($env:movetodevscope -eq "true") {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -318,7 +318,10 @@ function Invoke-4PSArtifactHandling {
 
                 
                 if ($env:IsBuildContainer -eq "false") {
-                   if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
+                    $ConstructNLFound = Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL'
+                    Write-Host "ConstructnL app found: $($ConstructNLFound -ne $null)"
+                    $ConstructNLFound
+                    if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `
                             -databaseServer $DatabaseServer `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -316,10 +316,10 @@ function Invoke-4PSArtifactHandling {
                 $timespent4PS = [Math]::Round([DateTime]::Now.Subtract($startTime4PS).Totalseconds)
                 Write-Host "  4PS initialization took $timespent4PS seconds"
 
-                
+                Write-Host "Moving all published apps to dev scope when possible"
                 if (-not $env:IsBuildContainer) {
                     $ConstructNLFound = Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL'
-                    Write-Host "ConstructnL app found: $($ConstructNLFound -ne $null)"
+                    Write-Host "ConstructNL app found: $($ConstructNLFound -ne $null)"
                     $ConstructNLFound
                     if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
                         Invoke-4PSMoveExtensionToDevScope `

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -317,7 +317,7 @@ function Invoke-4PSArtifactHandling {
                 Write-Host "  4PS initialization took $timespent4PS seconds"
 
                 
-                if ($env:IsBuildContainer -eq "false") {
+                if (-not $env:IsBuildContainer) {
                     $ConstructNLFound = Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL'
                     Write-Host "ConstructnL app found: $($ConstructNLFound -ne $null)"
                     $ConstructNLFound

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -268,6 +268,21 @@ function Invoke-4PSArtifactHandling {
                 $timespent4PS = [Math]::Round([DateTime]::Now.Subtract($startTime4PS).Totalseconds)
                 Write-Host "  4PS initialization took $timespent4PS seconds"
             }
+
+            if (-not ($env:IsBuildContainer -eq "true")) {
+                Write-Host "Move all published apps to dev scope for database '$appDatabaseName'"
+                $databaseName = "mydatabase"
+                $DatabaseServer = "localhost"
+                $DatabaseInstance = "SQLExpress"
+
+                $sqlParams = @{
+                    ServerInstance = "$DatabaseServer\$DatabaseInstance"
+                    ErrorAction    = "Stop"
+                }
+
+                Write-Host " - Moving all published apps to dev scope"
+                Invoke-Sqlcmd @sqlParams -Query "UPDATE [$databaseName].[dbo].[Published Application] SET [Published As] = 2, [Tenant ID] = 'default'" | Out-Null
+            }
         }
     }
 }

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -1,3 +1,50 @@
+function Invoke-4PSMoveExtensionToDevScope {
+    [cmdletbinding()]
+    PARAM
+    (
+        [parameter(Mandatory = $false)]
+        [string]$databaseName,
+        [parameter(Mandatory = $false)]
+        [string]$databaseServer,
+        [parameter(Mandatory = $false)]
+        [string]$databaseInstance
+    )
+    PROCESS {
+        try {
+            $needsServerConfig = [string]::IsNullOrWhiteSpace($databaseName) -or [string]::IsNullOrWhiteSpace($databaseServer) -or [string]::IsNullOrWhiteSpace($databaseInstance)
+
+            if ($needsServerConfig) {
+                $serverTierSettings = Get-NAVServerConfiguration -ServerInstance BC -ErrorAction SilentlyContinue
+
+                if ([string]::IsNullOrWhiteSpace($databaseName)) {
+                    $databaseName = ($serverTierSettings | Where-Object { $_.key -eq "DatabaseName" }).value
+                }
+                if ([string]::IsNullOrWhiteSpace($databaseServer)) {
+                    $databaseServer = ($serverTierSettings | Where-Object { $_.key -eq "DatabaseServer" }).value
+                }
+                if ([string]::IsNullOrWhiteSpace($databaseInstance)) {
+                    $databaseInstance = ($serverTierSettings | Where-Object { $_.key -eq "DatabaseInstance" }).value
+                }
+            }
+
+            if ([string]::IsNullOrWhiteSpace($databaseName) -or [string]::IsNullOrWhiteSpace($databaseServer) -or [string]::IsNullOrWhiteSpace($databaseInstance)) {
+                Write-Warning "Skipping move to dev scope: database settings are Empty. DatabaseName='$databaseName', DatabaseServer='$databaseServer', DatabaseInstance='$databaseInstance'"
+                return
+            }
+
+            Write-Host "Move all published apps to dev scope - Using SQL target $databaseServer\$databaseInstance / database '$databaseName'"
+            $sqlParams = @{
+                ServerInstance = "$databaseServer\$databaseInstance"
+                ErrorAction    = "Stop"
+            }
+            Invoke-Sqlcmd @sqlParams -Query "UPDATE [$databaseName].[dbo].[Published Application] SET [Published As] = 2, [Tenant ID] = 'default'" | Out-Null
+        }
+        catch {
+            Write-Warning "Failed to move published apps to dev scope: $_. Continuing with current scope."
+        }
+    }
+}
+
 function Invoke-4PSArtifactHandling {
     [cmdletbinding()]
     PARAM
@@ -18,14 +65,14 @@ function Invoke-4PSArtifactHandling {
             Write-Host "  app database name is: $appDatabaseName"
             $isModifiedBaseAppInstalled = ![string]::IsNullOrEmpty($env:cosmoBaseAppVersion)
             $isSaaSBak = ![string]::IsNullOrEmpty($env:saasbakfile)
-            if($isModifiedBaseAppInstalled -and !$isSaaSBak) {
+            if ($isModifiedBaseAppInstalled -and !$isSaaSBak) {
                 Write-Host "  modified base app was installed, therefore this is not a microsoft standard database"
             }
 
             if ($env:cosmoServiceRestart -eq $true) {
                 Write-Host "4PS initialization skipped as this seems to be a service restart"
             }
-            elseif($isSaaSBak) {
+            elseif ($isSaaSBak) {
                 Write-Host "4PS initialization skipped as this seems to be a SaaS backup restore"
             }
             elseif (("CRONUS" -eq $appDatabaseName) -or ("default" -eq $appDatabaseName) -and !$isModifiedBaseAppInstalled) {
@@ -270,18 +317,10 @@ function Invoke-4PSArtifactHandling {
             }
 
             if (-not ($env:IsBuildContainer -eq "true")) {
-                Write-Host "Move all published apps to dev scope for database '$appDatabaseName'"
-                $databaseName = "mydatabase"
-                $DatabaseServer = "localhost"
-                $DatabaseInstance = "SQLExpress"
-
-                $sqlParams = @{
-                    ServerInstance = "$DatabaseServer\$DatabaseInstance"
-                    ErrorAction    = "Stop"
-                }
-
-                Write-Host " - Moving all published apps to dev scope"
-                Invoke-Sqlcmd @sqlParams -Query "UPDATE [$databaseName].[dbo].[Published Application] SET [Published As] = 2, [Tenant ID] = 'default'" | Out-Null
+                Invoke-4PSMoveExtensionToDevScope `
+                    -databaseName $DatabaseName `
+                    -databaseServer $DatabaseServer `
+                    -databaseInstance $DatabaseInstance
             }
         }
     }

--- a/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
+++ b/artifacts/4PS/Invoke-4PSArtifactHandling.ps1
@@ -313,21 +313,19 @@ function Invoke-4PSArtifactHandling {
                 New-NAVAddin -ServerInstance BC -AddinName 'Microsoft.Dynamics.Nav.Client.WelcomeWizard' -PublicKeyToken 31bf3856ad364e35 -ResourceFile "$serviceTierFolder\Add-ins\WelcomeWizard\Microsoft.Dynamics.Nav.Client.WelcomeWizard.zip" -ErrorAction SilentlyContinue
                 Restart-NAVServerInstance BC
                 
-                $timespent4PS = [Math]::Round([DateTime]::Now.Subtract($startTime4PS).Totalseconds)
-                Write-Host "  4PS initialization took $timespent4PS seconds"
-
                 Write-Host "Moving all published apps to dev scope when possible"
                 if (-not $env:IsBuildContainer) {
-                    $ConstructNLFound = Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL'
-                    Write-Host "ConstructNL app found: $($ConstructNLFound -ne $null)"
-                    $ConstructNLFound
-                    if ($null -ne (Get-NAVAppInfo -ServerInstance bc -Name '4PS Construct NL')) {
+                    if ($env:AZURE_DEVOPS_PROJECT -eq '4PS_NL') {
                         Invoke-4PSMoveExtensionToDevScope `
                             -databaseName $DatabaseName `
                             -databaseServer $DatabaseServer `
                             -databaseInstance $DatabaseInstance   
                     }
                 }
+
+                $timespent4PS = [Math]::Round([DateTime]::Now.Subtract($startTime4PS).Totalseconds)
+                Write-Host "  4PS initialization took $timespent4PS seconds"
+
             }
         }
     }


### PR DESCRIPTION
1. When 4PS initialization starts & dev container is requested, try to move all extension to the devscope.
2. use default databaseName,databaseServer and databaseInstance. If they are not defined, pull the values form the service tier. Stop if the values cannot be found.
3.  Tested for Onprem containers and container based on SaaS backup (multitenant)
4. Only execute when 4PS initalization is required. do not use when backup, servicerestart etc. 
5. For phased rollout: Only do this for 4PS Construct NL for now. When no issues are found, then we can remove this line.

In usersettings.json add this setting to make container based on feature branche:
    "cc-azdevops.additionalFoldersOverride": "https://fps-alpaca.westeurope.cloudapp.azure.com/automation/0.11/startupfile/package/dev?branch=MoveToDevEndpoint"


Edit by Maintainer: fixes [AB#4870](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4870)
