### PR TITLE
feat(owners): add different username as user

### DIFF
--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -20,7 +20,7 @@ if ($env:auth -ieq "aad") {
 $PermissionSet = "SUPER"
 
 $accounts = @($env:owner.Split(","))
-if (-not [string]::IsNullOrEmpty($env:username) -and $env:username -inotin $accounts) {
+if (-not [string]::IsNullOrEmpty($env:username) -and $env:username -notin $accounts) {
     $accounts += $env:username
 }
 

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -20,6 +20,12 @@ if ($env:auth -ieq "aad") {
 $PermissionSet = "SUPER"
 
 $accounts = @($env:owner.Split(","))
+if (-not [string]::IsNullOrEmpty($env:username)) {
+    $alreadyIncluded = $accounts | Where-Object { $_ -ieq $env:username }
+    if (-not $alreadyIncluded) {
+        $accounts += $env:username
+    }
+}
 
 Wait-NAVTenantReady -ServerInstance $ServerInstance -Tenant $tenantId -Retries 60 -OutputPrefix "  "
 

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -28,6 +28,10 @@ Wait-NAVTenantReady -ServerInstance $ServerInstance -Tenant $tenantId -Retries 6
 
 
 foreach ($account in $accounts) {
+    if (-not $navuserpasswordAuth -and $account -notlike "*@*") {
+        Write-Host "  Skipping account '$account': does not contain '@', not valid for AAD auth."
+        continue
+    }
     Write-Host "  Processing account: $account"
     $BcUser = $null
     $shortenedAccount = $account.Split("@")[0]

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -20,11 +20,8 @@ if ($env:auth -ieq "aad") {
 $PermissionSet = "SUPER"
 
 $accounts = @($env:owner.Split(","))
-if (-not [string]::IsNullOrEmpty($env:username)) {
-    $alreadyIncluded = $accounts | Where-Object { $_ -ieq $env:username }
-    if (-not $alreadyIncluded) {
-        $accounts += $env:username
-    }
+if (-not [string]::IsNullOrEmpty($env:username) -and $env:username -inotin $accounts) {
+    $accounts += $env:username
 }
 
 Wait-NAVTenantReady -ServerInstance $ServerInstance -Tenant $tenantId -Retries 60 -OutputPrefix "  "

--- a/misc/AdditionalSetupAdditionalOwners.ps1
+++ b/misc/AdditionalSetupAdditionalOwners.ps1
@@ -29,7 +29,7 @@ Wait-NAVTenantReady -ServerInstance $ServerInstance -Tenant $tenantId -Retries 6
 
 foreach ($account in $accounts) {
     if (-not $navuserpasswordAuth -and $account -notlike "*@*") {
-        Write-Host "  Skipping account '$account': does not contain '@', not valid for AAD auth."
+        Write-Host "  Skipping account '$account', not valid for AAD auth."
         continue
     }
     Write-Host "  Processing account: $account"


### PR DESCRIPTION
This pull request makes improvements to the handling of account processing in the `misc/AdditionalSetupAdditionalOwners.ps1` script, specifically for AAD authentication scenarios. The main focus is on ensuring that the current username is included in the accounts list if not already present, and on skipping accounts that are not valid for AAD authentication.

**Account handling improvements:**

* Ensured that the current username (`$env:username`) is added to the `$accounts` list if it is not already present, preventing accidental omission.
* Added logic to skip processing of accounts that do not contain an `@` symbol (i.e., are not valid AAD accounts) when not using `navuserpassword` authentication, with a clear log message for skipped accounts.

[AB#4862](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4862)