### PR TITLE
fix(artifacts): cache only string values for infos of installed app on download of NuGet artifacts

### DIFF
--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -112,10 +112,10 @@ function Invoke-NuGetPackageDownload() {
                             $appInfoObj = Get-NavAppInfo -Path $installedAppFile.FullName
                             $appInfo = [PSCustomObject]@{
                                 Package   = '{0}.{1}.{2}' -f $appInfoObj.Publisher, $appInfoObj.Name, $appInfoObj.AppId -replace ' '
-                                Name      = $appInfoObj.Name
-                                Publisher = $appInfoObj.Publisher
-                                Id        = $appInfoObj.AppId
-                                Version   = $appInfoObj.Version
+                                Name      = [string] $appInfoObj.Name
+                                Publisher = [string] $appInfoObj.Publisher
+                                Id        = [string] $appInfoObj.AppId
+                                Version   = [string] $appInfoObj.Version
                             }
                             $appInfosCache[$appInfoCacheKey] = $appInfo
                             $appInfosCacheUpdated = $true


### PR DESCRIPTION
This pull request makes a small update to the `Invoke-NuGetPackageDownload.ps1` script to ensure that certain application metadata fields are always stored as strings. This change improves type consistency and reduces the risk of type-related errors.

- Ensured that the `Name`, `Publisher`, `Id`, and `Version` fields in the `$appInfo` object are explicitly cast to strings when extracting application info.

Fixes [AB#4874](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4874) 