### PR TITLE
feat(artifacts): retry failed downloads

### DIFF
--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifact.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifact.ps1
@@ -30,6 +30,7 @@ function Invoke-DownloadArtifact {
         [string[]]$ApiFeatures,
         [string]  $ServiceTierFolder,
         [int]     $FolderIdx         = 0,
+        [int]     $Retries           = 3,
 
         # Control Parameters
         [switch]$PassThru,
@@ -94,6 +95,7 @@ function Invoke-DownloadArtifact {
             ApiFeatures = $ApiFeatures
             ServiceTierFolder = $ServiceTierFolder
             FolderIdx = $FolderIdx
+            Retries = $Retries
         }
 
         if (! $PassThru) {

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactAsync.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactAsync.ps1
@@ -16,13 +16,14 @@ function Invoke-DownloadArtifactAsync {
         [string[]]$ApiFeatures,
         [string]  $ServiceTierFolder,
         [int]     $FolderIdx         = 0,
+        [int]     $Retries           = 3,
 
         # Async Parameters
         [Parameter(Mandatory)]
         [System.Management.Automation.Runspaces.RunspacePool]$RunspacePool,
         [switch]$OneRunspace
     )
-    
+
     begin {
         $artifacts = @()
 
@@ -43,7 +44,7 @@ function Invoke-DownloadArtifactAsync {
 
         $scriptBlock = {
             param(
-                [object[]]$Artifacts, 
+                [object[]]$Artifacts,
                 [hashtable]$Parameters
             )
             try {
@@ -55,17 +56,17 @@ function Invoke-DownloadArtifactAsync {
             }
         }
     }
-    
+
     process {
         # Collect given artifacts
         $artifacts += $Artifact
     }
-    
+
     end {
         if (! $artifacts) {
             return
         }
-        
+
         if (! $PSBoundParameters.ContainsKey("ServiceTierFolder")) {
             $ServiceTierFolder = Get-NAVServiceTierFolder
         }
@@ -92,6 +93,7 @@ function Invoke-DownloadArtifactAsync {
                         ApiFeatures = $ApiFeatures
                         ServiceTierFolder = $ServiceTierFolder
                         FolderIdx = $FolderIdx
+                        Retries = $Retries
                     }
                 }
 

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -140,7 +140,7 @@ function Invoke-DownloadArtifactCore {
 
                                 New-ArtifactsLogEntry -Message "Download artifact failed (attempt $attempt of $maxAttempts): $($_.Exception.Message)" -Severity Warn
                                 $waitSeconds = [Math]::Pow(2, $attempt - 1)
-                                Write-Host "Retrying after $waitSeconds second(s)..."
+                                New-ArtifactsLogEntry -Message "Retrying after $waitSeconds second(s)..."
                                 Start-Sleep -Seconds $waitSeconds
                             }
                         }

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -29,7 +29,8 @@ function Invoke-DownloadArtifactCore {
         [string]  $accessToken,
         [string[]]$apiFeatures,
         [string]  $serviceTierFolder,
-        [int]     $folderIdx
+        [int]     $folderIdx,
+        [int]     $retries
     )
 
     begin {
@@ -54,6 +55,8 @@ function Invoke-DownloadArtifactCore {
                 }
             }
         )
+
+        $maxAttempts = $retries + 1
     }
 
     process {
@@ -126,7 +129,21 @@ function Invoke-DownloadArtifactCore {
                             $invokeWebRequestSplat += @{ Method = 'Get' }
                             New-ArtifactsLogEntry -Message "External artifact URL detected, ignoring Authorization header" -Severity Debug
                         }
-                        $response = Invoke-WebRequest @invokeWebRequestSplat
+                        foreach ($attempt in 1..$maxAttempts) {
+                            try {
+                                New-ArtifactsLogEntry -Message "Download artifact (attempt $attempt of $maxAttempts)"
+                                $response = Invoke-WebRequest @invokeWebRequestSplat
+                            } catch {
+                                if ($attempt -ge $maxAttempts) {
+                                    throw
+                                }
+
+                                New-ArtifactsLogEntry -Message "Download artifact failed (attempt $attempt of $maxAttempts): $($_.Exception.Message)" -Severity Warn
+                                $waitSeconds = [Math]::Pow(2, $attempt - 1)
+                                Write-Host "Retrying after $waitSeconds second(s)..."
+                                Start-Sleep -Seconds $waitSeconds
+                            }
+                        }
 
                         # Determine file type based on Content-Disposition header or content signature
                         $fileType = ''
@@ -230,6 +247,7 @@ function Invoke-DownloadArtifactCore {
                             ServiceTierFolder  = $serviceTierFolder
                             PlatformVersion    = $platformVersion
                             PredefinedPackages = $predefinedNuGetPackages
+                            Retries            = $retries
                         }
                         Invoke-NuGetPackageDownload @nuGetParameters *>&1 |
                             Where-Object { $_ -ne $null } |
@@ -240,14 +258,14 @@ function Invoke-DownloadArtifactCore {
                                     ( [System.Management.Automation.WarningRecord] )     { New-ArtifactsLogEntry -Message $output.ToString() -Severity Warn }
                                     ( [System.Management.Automation.VerboseRecord] )     { Write-Verbose $output }
                                     ( [System.Management.Automation.DebugRecord] )       { New-ArtifactsLogEntry -Message $output.ToString() -Severity Debug }
-                                    ( [System.Management.Automation.InformationRecord] ) {
-                                        $output |
-                                            Where-Object { $_.ToString() -notmatch "^Search NuGetFeed " } |
-                                            Where-Object { $_.ToString() -notmatch "^Search package using " } |
-                                            Where-Object { $_.ToString() -notmatch "^0 matching packages found" } |
-                                            ForEach-Object {
-                                                New-ArtifactsLogEntry -Message $_.ToString() -Severity Info
-                                            }
+                                    ( [System.Management.Automation.InformationRecord] ) { New-ArtifactsLogEntry -Message $output.ToString() -Severity Info
+                                        # $output |
+                                        #     Where-Object { $_.ToString() -notmatch "^Search NuGetFeed " } |
+                                        #     Where-Object { $_.ToString() -notmatch "^Search package using " } |
+                                        #     Where-Object { $_.ToString() -notmatch "^0 matching packages found" } |
+                                        #     ForEach-Object {
+                                        #         New-ArtifactsLogEntry -Message $_.ToString() -Severity Info
+                                        #     }
                                     }
                                 }
                             }

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -258,15 +258,7 @@ function Invoke-DownloadArtifactCore {
                                     ( [System.Management.Automation.WarningRecord] )     { New-ArtifactsLogEntry -Message $output.ToString() -Severity Warn }
                                     ( [System.Management.Automation.VerboseRecord] )     { Write-Verbose $output }
                                     ( [System.Management.Automation.DebugRecord] )       { New-ArtifactsLogEntry -Message $output.ToString() -Severity Debug }
-                                    ( [System.Management.Automation.InformationRecord] ) { New-ArtifactsLogEntry -Message $output.ToString() -Severity Info
-                                        # $output |
-                                        #     Where-Object { $_.ToString() -notmatch "^Search NuGetFeed " } |
-                                        #     Where-Object { $_.ToString() -notmatch "^Search package using " } |
-                                        #     Where-Object { $_.ToString() -notmatch "^0 matching packages found" } |
-                                        #     ForEach-Object {
-                                        #         New-ArtifactsLogEntry -Message $_.ToString() -Severity Info
-                                        #     }
-                                    }
+                                    ( [System.Management.Automation.InformationRecord] ) { New-ArtifactsLogEntry -Message $output.ToString() -Severity Info }
                                 }
                             }
                     } elseif ($isArchive) {

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -30,6 +30,7 @@ function Invoke-DownloadArtifactCore {
         [string[]]$apiFeatures,
         [string]  $serviceTierFolder,
         [int]     $folderIdx,
+        [ValidateRange(0, [int]::MaxValue)]
         [int]     $retries
     )
 

--- a/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
+++ b/artifacts/ArtifactHandling/Invoke-DownloadArtifactCore.ps1
@@ -133,6 +133,7 @@ function Invoke-DownloadArtifactCore {
                             try {
                                 New-ArtifactsLogEntry -Message "Download artifact (attempt $attempt of $maxAttempts)"
                                 $response = Invoke-WebRequest @invokeWebRequestSplat
+                                break
                             } catch {
                                 if ($attempt -ge $maxAttempts) {
                                     throw

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -202,6 +202,7 @@ function Invoke-NuGetPackageDownload() {
                 try {
                     Write-Verbose -Message "Download NuGet package $Package (attempt $attempt of $maxAttempts)"
                     Download-BcNuGetPackageToFolder @downloadParameters
+                    break
                 } catch {
                     if ($attempt -ge $maxAttempts) {
                         throw

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -12,6 +12,7 @@ function Invoke-NuGetPackageDownload() {
         [string]$ServiceTierFolder,
         [Version]$PlatformVersion,
         [PSCustomObject[]]$PredefinedPackages = @(),
+        [ValidateRange(0, [int]::MaxValue)]
         [int]$Retries = 0
     )
 

--- a/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
+++ b/artifacts/ArtifactHandling/NuGet/Invoke-NuGetPackageDownload.ps1
@@ -11,7 +11,8 @@ function Invoke-NuGetPackageDownload() {
         [string]$InstalledAppsPath,
         [string]$ServiceTierFolder,
         [Version]$PlatformVersion,
-        [PSCustomObject[]]$PredefinedPackages = @()
+        [PSCustomObject[]]$PredefinedPackages = @(),
+        [int]$Retries = 0
     )
 
     begin {
@@ -25,6 +26,8 @@ function Invoke-NuGetPackageDownload() {
         $versionRangePattern  = '^\s*[\[\(]?\s*({0}{1})(,{0}{1})?\s*[\]\)]?\s*$' -f $versionStablePattern, $versionPrereleasePattern # [[(] <major>[.<minor>[.<patch>[.<revision>]]][-<prerelease>] [, <major>[.<minor>[.<patch>[.<revision>]]][-<prerelease>]] [)]]
 
         $appInfosCacheFileName = ".nuget.apps.cache.json"
+
+        $maxAttempts = $Retries + 1
     }
 
     process {
@@ -195,7 +198,21 @@ function Invoke-NuGetPackageDownload() {
             }
 
             New-Item -ItemType Directory -Path $Destination -ErrorAction SilentlyContinue -Force | Out-Null
-            Download-BcNuGetPackageToFolder @downloadParameters
+            foreach($attempt in 1..$maxAttempts) {
+                try {
+                    Write-Verbose -Message "Download NuGet package $Package (attempt $attempt of $maxAttempts)"
+                    Download-BcNuGetPackageToFolder @downloadParameters
+                } catch {
+                    if ($attempt -ge $maxAttempts) {
+                        throw
+                    }
+
+                    Write-Warning "Download NuGet package $Package failed (attempt $attempt of $maxAttempts): $($_.Exception.Message)"
+                    $waitSeconds = [Math]::Pow(2, $attempt - 1)
+                    Write-Host "Retrying after $waitSeconds second(s)..."
+                    Start-Sleep -Seconds $waitSeconds
+                }
+            }
         } finally {
             if ($nuGetPackageDownloadLockFileStream) {
                 $nuGetPackageDownloadLockFileStream.Close()


### PR DESCRIPTION
Implements [AB#4882](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4882)

- Adds retry to the download of the artifacts
- Removes unnecessary filter of NuGet download output
  - was previously needed to reduce the output for our many NuGet feeds (one per solution)