### PR TITLE
fix: Improve Module loading for future version compatibility

### DIFF
--- a/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
+++ b/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
@@ -223,7 +223,7 @@ function Invoke-PwshOverwriting {
 
         # Ensure the module containing the target commands is loaded in the current session to retrieve parameter metadata
         if (! (Get-Module 'Microsoft.Dynamics.Nav.Management')) {
-            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" | ForEach-Object { . $_ }
+            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" | ForEach-Object { Import-Module $_ }
         }
     }
     process {

--- a/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
+++ b/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
@@ -223,7 +223,7 @@ function Invoke-PwshOverwriting {
 
         # Ensure the module containing the target commands is loaded in the current session to retrieve parameter metadata
         if (! (Get-Module 'Microsoft.Dynamics.Nav.Management')) {
-            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Admin\NavAdminTool.ps1" | ForEach-Object { . $_ }
+            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" | ForEach-Object { . $_ }
         }
     }
     process {

--- a/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
+++ b/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
@@ -223,7 +223,9 @@ function Invoke-PwshOverwriting {
 
         # Ensure the module containing the target commands is loaded in the current session to retrieve parameter metadata
         if (! (Get-Module 'Microsoft.Dynamics.Nav.Management')) {
-            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" | ForEach-Object { Import-Module $_ }
+            Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.psm1" | ForEach-Object { Write-Host "Importing module: $_";Import-Module $_ }
+        } else {
+            Write-Host "Module 'Microsoft.Dynamics.Nav.Management' is already loaded."
         }
     }
     process {

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -32,7 +32,7 @@ if ($bcVersion.Major -ge 29) {
     catch {
         throw "PowerShell Core ('pwsh') is required but was not found. Ensure that PowerShell Core is installed and 'pwsh' is available on PATH."
     }
-    Import-Module "C:\Program Files\Microsoft Dynamics NAV\290\Service\Admin\Microsoft.BusinessCentral.Apps.Management.psd1" -Global
+    Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Admin\Microsoft.BusinessCentral.Apps.Management.psd1" | ForEach-Object { Write-Host "Importing module: $_";Import-Module $_ -Global}
     Invoke-PwshOverwriting -commandNames ($commandNamesForManagement)
 
     Get-PwshCoreSessionConfiguration | Out-Null

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -10,22 +10,34 @@ if (! (Get-Module 'PPIPowershellCoreUtils')) {
 }
 
 $commandNamesForAppManagement = @(
-    'Get-NavAppRuntimePackage', 
-    'Install-NAVApp', 
-    'Invoke-InplacePublishing', 
-    'Publish-NAVApp', 
-    'Repair-NAVApp', 
-    'Start-NAVAppDataUpgrade', 
-    'Sync-NAVApp', 
-    'Uninstall-NAVApp', 
+    'Get-NavAppRuntimePackage',
+    'Install-NAVApp',
+    'Invoke-InplacePublishing',
+    'Publish-NAVApp',
+    'Repair-NAVApp',
+    'Start-NAVAppDataUpgrade',
+    'Sync-NAVApp',
+    'Uninstall-NAVApp',
     'Unpublish-NAVApp'
-) 
+)
 
 $commandNamesForManagement = @(
     'Mount-NAVTenant'
-) 
+)
+if ($bcVersion.Major -ge 29) {
+    # Validate that PowerShell Core (pwsh) is available up front for the BC29+ path
+    try {
+        Get-Command pwsh -ErrorAction Stop | Out-Null
+    }
+    catch {
+        throw "PowerShell Core ('pwsh') is required but was not found. Ensure that PowerShell Core is installed and 'pwsh' is available on PATH."
+    }
+    Import-Module "C:\Program Files\Microsoft Dynamics NAV\290\Service\Admin\Microsoft.BusinessCentral.Apps.Management.psd1" -Global
+    Invoke-PwshOverwriting -commandNames ($commandNamesForManagement)
 
-if ($bcVersion.Major -ge 28) {
+    Get-PwshCoreSessionConfiguration | Out-Null
+}
+elseif ($bcVersion.Major -eq 28) {
     # Validate that PowerShell Core (pwsh) is available up front for the BC28+ path
     try {
         Get-Command pwsh -ErrorAction Stop | Out-Null
@@ -34,7 +46,7 @@ if ($bcVersion.Major -ge 28) {
         throw "PowerShell Core ('pwsh') is required but was not found. Ensure that PowerShell Core is installed and 'pwsh' is available on PATH."
     }
     Invoke-PwshOverwriting -commandNames ($commandNamesForAppManagement + $commandNamesForManagement)
-    
+
     Get-PwshCoreSessionConfiguration | Out-Null
 }
 else {
@@ -42,7 +54,7 @@ else {
     Get-PwshCoreSessionConfiguration | Out-Null
 
     $moduleImportScriptBlock = { c:\run\prompt.ps1 -silent }
-   
+
     $commandNamesForAppManagement | ForEach-Object {
         Export-PwshCoreOverride -CommandName $_ -ModuleName 'Microsoft.BusinessCentral.Apps.Management' -ModuleImportScriptBlock $moduleImportScriptBlock
     }


### PR DESCRIPTION
This pull request improves the robustness and clarity of PowerShell module loading and version checks for Business Central management scripts. The main updates ensure that required modules are properly loaded and provide clearer feedback to users, especially for Business Central 29 and above.

**PowerShell Core and Module Loading Enhancements:**

* For Business Central 29+, the script now explicitly checks for the presence of PowerShell Core (`pwsh`) and throws a clear error if it's not found. It also imports the `Microsoft.BusinessCentral.Apps.Management.psd1` module globally and invokes the necessary overwriting logic.
* The module loading logic for `Microsoft.Dynamics.Nav.Management` in `Invoke-PwshOverwriting` is improved to use `Import-Module` with a descriptive message, ensuring the correct module is loaded and providing user feedback if it is already present.

[AB#4900](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4900)