### PR TITLE
fix(bc29): add override for "Get-NAVAppInfo" and convert AppId to Guid

### DIFF
--- a/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
+++ b/base/helper/PPIOverrides/private/Export-PwshCoreOverride.ps1
@@ -18,6 +18,8 @@ function Export-PwshCoreOverride() {
         [Parameter(ParameterSetName = 'ModuleImportScriptBlock', Mandatory)]
         [scriptblock]$ModuleImportScriptBlock,
 
+        [scriptblock]$ForEachOutputScriptBlock = { $_ },
+
         [bool]$UseRemoteSession = $true
     )
 
@@ -125,7 +127,8 @@ function Export-PwshCoreOverride() {
                 Invoke-CommandInPwshCore `
                     -ScriptBlock $pwshCoreScriptBlock `
                     -ArgumentList $overrideInfo, $PSBoundParameters `
-                    -UseRemoteSession $overrideInfo.UseRemoteSession
+                    -UseRemoteSession $overrideInfo.UseRemoteSession |
+                    ForEach-Object $ForEachOutputScriptBlock
             }
         }
     }

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -37,7 +37,6 @@ $forEachOutputScriptBlock = { $_ }
 if ($bcVersion.Major -ge 29) {
     # For BC29 and higher, we will also override Get-NAVAppInfo to handle issues with the returned AppId
     # The returned deserialized object for the AppId can not be passed directly to other NAV App cmdlets because they expect a Guid
-    # For this we also add a ForEach-Object scriptblock to convert the deserialized AppId object to a Guid by returning the Value property of the deserialized AppId object instead of the deserialized object itself
     $commandNamesForAppManagement += 'Get-NAVAppInfo'
 
     $forEachOutputScriptBlock = {

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -44,13 +44,14 @@ if ($bcVersion.Major -ge 29) {
         $object = $_
 
         # Return the object if it is not a PS Object
-        if ($null -eq $object) { return $object }
         if ($object -isnot [PSObject]) { return $object }
 
         # Resolve properties of deserialized NavAppInfoDetail
-        if ($object.PSObject.TypeNames -contains 'Deserialized.Microsoft.Dynamics.Nav.Apps.Management.Cmdlets.NavAppInfoDetail') {
+        if ($object.PSObject.TypeNames -contains 'Deserialized.Microsoft.Dynamics.Nav.Apps.Management.Cmdlets.NavAppInfo') {
             $object.PSObject.Properties |
                 Where-Object { $_.Name -in 'AppId', 'PackageId' } |
+                Where-Object { $_.Value -is [PSObject] } |
+                Where-Object { $_.Value.PSObject.TypeNames -like 'Deserialized.*' } |
                 ForEach-Object {
                     $_.Value = $_.Value.Value
                 }

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -46,7 +46,7 @@ if ($bcVersion.Major -ge 29) {
         # Return the object if it is not a PS Object
         if ($object -isnot [PSObject]) { return $object }
 
-        # Resolve properties of deserialized NavAppInfoDetail
+        # Resolve properties of deserialized NavAppInfo
         if ($object.PSObject.TypeNames -contains 'Deserialized.Microsoft.Dynamics.Nav.Apps.Management.Cmdlets.NavAppInfo') {
             $object.PSObject.Properties |
                 Where-Object { $_.Name -in 'AppId', 'PackageId' } |

--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -32,10 +32,48 @@ $useRemoteSession = $bcVersion.Major -lt 28 # For BC28 and higher the import of 
 
 $moduleImportScriptBlock = { c:\run\prompt.ps1 -silent }
 
+$forEachOutputScriptBlock = { $_ }
+
+if ($bcVersion.Major -ge 29) {
+    # For BC29 and higher, we will also override Get-NAVAppInfo to handle issues with the returned AppId
+    # The returned deserialized object for the AppId can not be passed directly to other NAV App cmdlets because they expect a Guid
+    # For this we also add a ForEach-Object scriptblock to convert the deserialized AppId object to a Guid by returning the Value property of the deserialized AppId object instead of the deserialized object itself
+    $commandNamesForAppManagement += 'Get-NAVAppInfo'
+
+    $forEachOutputScriptBlock = {
+        $object = $_
+
+        # Return the object if it is not a PS Object
+        if ($null -eq $object) { return $object }
+        if ($object -isnot [PSObject]) { return $object }
+
+        # Resolve properties of deserialized NavAppInfoDetail
+        if ($object.PSObject.TypeNames -contains 'Deserialized.Microsoft.Dynamics.Nav.Apps.Management.Cmdlets.NavAppInfoDetail') {
+            $object.PSObject.Properties |
+                Where-Object { $_.Name -in 'AppId', 'PackageId' } |
+                ForEach-Object {
+                    $_.Value = $_.Value.Value
+                }
+        }
+
+        return $object
+    }
+}
+
 $commandNamesForAppManagement | ForEach-Object {
-    Export-PwshCoreOverride -CommandName $_ -ModuleName 'Microsoft.BusinessCentral.Apps.Management' -ModuleImportScriptBlock $moduleImportScriptBlock -UseRemoteSession $useRemoteSession
+    Export-PwshCoreOverride `
+        -CommandName $_ `
+        -ModuleName 'Microsoft.BusinessCentral.Apps.Management' `
+        -ModuleImportScriptBlock $moduleImportScriptBlock `
+        -ForEachOutputScriptBlock $forEachOutputScriptBlock `
+        -UseRemoteSession $useRemoteSession
 }
 
 $commandNamesForManagement | ForEach-Object {
-    Export-PwshCoreOverride -CommandName $_ -ModuleName 'Microsoft.BusinessCentral.Management' -ModuleImportScriptBlock $moduleImportScriptBlock -UseRemoteSession $useRemoteSession
+    Export-PwshCoreOverride `
+        -CommandName $_ `
+        -ModuleName 'Microsoft.BusinessCentral.Management' `
+        -ModuleImportScriptBlock $moduleImportScriptBlock `
+        -ForEachOutputScriptBlock $forEachOutputScriptBlock `
+        -UseRemoteSession $useRemoteSession
 }


### PR DESCRIPTION
**Enhancements for Business Central 29+ compatibility:**

* Added a conditional override for `Get-NAVAppInfo` when running on BC29 or higher to convert deserialized `AppId` and `PackageId` properties to their underlying `Value` (GUID) before returning, ensuring compatibility with other cmdlets that expect GUIDs.

**Extensibility and output handling improvements:**

* Introduced the `ForEachOutputScriptBlock` parameter to `Export-PwshCoreOverride`, allowing custom processing of each output object from the overridden command.
* Updated calls to `Export-PwshCoreOverride` for both App Management and Management commands to pass the new `ForEachOutputScriptBlock` parameter.
* Modified the invocation of the underlying command in `Export-PwshCoreOverride` to pipe output through the provided `ForEachOutputScriptBlock`, enabling transformation of results as needed.

Fixes [AB#4918](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4918)
Fixes [AB#4919](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4919)