### PR TITLE
fix(bc29): convert more deserialized NavAppInfo properties

### DIFF
--- a/base/helper/PPIOverrides/public/NavAppManagement.ps1
+++ b/base/helper/PPIOverrides/public/NavAppManagement.ps1
@@ -48,7 +48,7 @@ if ($bcVersion.Major -ge 29) {
         # Resolve properties of deserialized NavAppInfo
         if ($object.PSObject.TypeNames -contains 'Deserialized.Microsoft.Dynamics.Nav.Apps.Management.Cmdlets.NavAppInfo') {
             $object.PSObject.Properties |
-                Where-Object { $_.Name -in 'AppId', 'PackageId' } |
+                Where-Object { $_.Name -in 'AppId', 'PackageId', 'Scope', 'ExtensionType' } |
                 Where-Object { $_.Value -is [PSObject] } |
                 Where-Object { $_.Value.PSObject.TypeNames -like 'Deserialized.*' } |
                 ForEach-Object {


### PR DESCRIPTION
Updated the property filter in the deserialized `NavAppInfo` handling to include `Scope` and `ExtensionType` properties, in addition to the existing `AppId` and `PackageId`. This ensures these additional properties are also properly resolved when working with deserialized objects.

Fixes [AB#4925](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4925)