### PR TITLE
Create DEFAULT Test Suite on Container start

### DIFF
--- a/base/AdditionalSetup.ps1
+++ b/base/AdditionalSetup.ps1
@@ -2,7 +2,8 @@ $scripts = @(
                         (Join-Path $PSScriptRoot "AdditionalSetupArtifacts.ps1"),
                         (Join-Path $PSScriptRoot "AdditionalSetupPrerequisites.ps1"),
                         (Join-Path $PSScriptRoot "AdditionalSetupDuplicateUsers.ps1"),
-                        (Join-Path $PSScriptRoot "AdditionalSetupAdditionalOwners.ps1")
+                        (Join-Path $PSScriptRoot "AdditionalSetupAdditionalOwners.ps1"),
+                        (Join-Path $PSScriptRoot "AdditionalSetupCreateTestSuite.ps1")
 )
 
 Write-Host "Start AdditionalSetup"

--- a/misc/AdditionalSetupCreateTestSuite.ps1
+++ b/misc/AdditionalSetupCreateTestSuite.ps1
@@ -1,0 +1,27 @@
+Write-Host "Create DEFAULT Test Suite"
+
+Write-Host "Collecting information about the current user, server instance, tenant, and company..."
+$me = whoami
+$ServerInstance = Get-NAVServerInstance
+$Tenant = $ServerInstance | Get-NAVTenant
+$Company = Get-NAVCompany -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Select-Object -First 1
+$myaccount = get-navserveruser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Where-Object { $_.WindowsAccount -eq $me }
+
+if ($null -eq $myaccount) {
+    Write-Host "Adding $me as a user to the tenant $($Tenant.Id) and assigning SUPER permission set"
+    New-NAVServerUser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -WindowsAccount $me
+    New-NAVServerUserPermissionSet -WindowsAccount $me -PermissionSetId SUPER -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id
+}
+
+Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $($Tenant.Id)"
+try {
+    Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT'
+}
+catch {
+    Write-Host "Error creating DEFAULT Test Suite: $($_.Exception.Message)"
+}
+
+if ($null -eq $myaccount) {
+    Write-Host "Removing $me as a user from the tenant $($Tenant.Id)"
+    Remove-NAVServerUser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -WindowsAccount $me
+}

--- a/misc/AdditionalSetupCreateTestSuite.ps1
+++ b/misc/AdditionalSetupCreateTestSuite.ps1
@@ -15,7 +15,7 @@ if ($null -eq $myaccount) {
 
 Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $($Tenant.Id)"
 try {
-    Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT'
+    Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT' -ErrorAction Stop
 }
 catch {
     Write-Host "Error creating DEFAULT Test Suite: $($_.Exception.Message)"

--- a/misc/AdditionalSetupCreateTestSuite.ps1
+++ b/misc/AdditionalSetupCreateTestSuite.ps1
@@ -12,9 +12,9 @@ if ($null -eq $myaccount) {
 }
 
 foreach ($Company in $Companies) {
-    Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $($Tenant.Id)"
+    Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $tenantId"
     try {
-        Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT' -ErrorAction Stop
+        Invoke-NAVCodeunit -ServerInstance $ServerInstance -Tenant $tenantId -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT' -ErrorAction Stop
     }
     catch {
         Write-Host "Error creating DEFAULT Test Suite: $($_.Exception.Message)"
@@ -22,6 +22,6 @@ foreach ($Company in $Companies) {
 }
 
 if ($null -eq $myaccount) {
-    Write-Host "Removing $me as a user from the tenant $($Tenant.Id)"
-    Remove-NAVServerUser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -WindowsAccount $me
+    Write-Host "Removing $me as a user from the tenant $tenantId"
+    Remove-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -WindowsAccount $me
 }

--- a/misc/AdditionalSetupCreateTestSuite.ps1
+++ b/misc/AdditionalSetupCreateTestSuite.ps1
@@ -4,7 +4,7 @@ Write-Host "Collecting information about the current user, server instance, tena
 $me = whoami
 $ServerInstance = Get-NAVServerInstance
 $Tenant = $ServerInstance | Get-NAVTenant
-$Company = Get-NAVCompany -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Select-Object -First 1
+$Companies = Get-NAVCompany -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Where-Object { $_.CompanyName -ne "My Company" }
 $myaccount = get-navserveruser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Where-Object { $_.WindowsAccount -eq $me }
 
 if ($null -eq $myaccount) {
@@ -13,12 +13,14 @@ if ($null -eq $myaccount) {
     New-NAVServerUserPermissionSet -WindowsAccount $me -PermissionSetId SUPER -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id
 }
 
-Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $($Tenant.Id)"
-try {
-    Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT' -ErrorAction Stop
-}
-catch {
-    Write-Host "Error creating DEFAULT Test Suite: $($_.Exception.Message)"
+foreach ($Company in $Companies) {
+    Write-Host "Creating DEFAULT Test Suite in the company $($Company.CompanyName) of the tenant $($Tenant.Id)"
+    try {
+        Invoke-NAVCodeunit -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -CompanyName $Company.CompanyName -CodeunitId 130456 -MethodName 'CreateTestSuite' -Argument 'DEFAULT' -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Error creating DEFAULT Test Suite: $($_.Exception.Message)"
+    }
 }
 
 if ($null -eq $myaccount) {

--- a/misc/AdditionalSetupCreateTestSuite.ps1
+++ b/misc/AdditionalSetupCreateTestSuite.ps1
@@ -2,15 +2,13 @@ Write-Host "Create DEFAULT Test Suite"
 
 Write-Host "Collecting information about the current user, server instance, tenant, and company..."
 $me = whoami
-$ServerInstance = Get-NAVServerInstance
-$Tenant = $ServerInstance | Get-NAVTenant
-$Companies = Get-NAVCompany -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Where-Object { $_.CompanyName -ne "My Company" }
-$myaccount = get-navserveruser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id | Where-Object { $_.WindowsAccount -eq $me }
+$Companies = Get-NAVCompany -ServerInstance $ServerInstance -Tenant $tenantId | Where-Object { $_.CompanyName -ne "My Company" }
+$myaccount = Get-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId | Where-Object { $_.WindowsAccount -eq $me }
 
 if ($null -eq $myaccount) {
-    Write-Host "Adding $me as a user to the tenant $($Tenant.Id) and assigning SUPER permission set"
-    New-NAVServerUser -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id -WindowsAccount $me
-    New-NAVServerUserPermissionSet -WindowsAccount $me -PermissionSetId SUPER -ServerInstance $ServerInstance.ServerInstance -Tenant $Tenant.Id
+    Write-Host "Adding $me as a user to the tenant $tenantId and assigning SUPER permission set"
+    New-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenantId -WindowsAccount $me
+    New-NAVServerUserPermissionSet -WindowsAccount $me -PermissionSetId SUPER -ServerInstance $ServerInstance -Tenant $tenantId
 }
 
 foreach ($Company in $Companies) {


### PR DESCRIPTION
This pull request adds a new step to the additional setup process to automatically create a default test suite in the environment. The main changes include updating the script list to include the new setup script and implementing the logic to create the test suite, ensuring the current user has the necessary permissions.

**Enhancements to setup process:**

* [`base/AdditionalSetup.ps1`](diffhunk://#diff-b3bac7a9a60c6b758c16b6e1562b3bea6847f041238e954518b99c534b4e0e2fL5-R6): Added `AdditionalSetupCreateTestSuite.ps1` to the list of additional setup scripts to be executed.

**Test suite automation:**

* [`misc/AdditionalSetupCreateTestSuite.ps1`](diffhunk://#diff-88fec4a436cb31a63cbcc39e5db915dd9038f0b6ca5376a23be4b882618cb96bR1-R27): Introduced a script that collects environment details, ensures the current user has the required permissions, creates a "DEFAULT" test suite via a codeunit invocation, and cleans up any temporary user accounts created during the process.

[AB#4931](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4931)

